### PR TITLE
versioning: use git directly from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,34 @@
 cmake_minimum_required(VERSION 3.3)
 cmake_policy(VERSION 3.3)
 
-execute_process(COMMAND git describe --tags
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                RESULT_VARIABLE GIT_VERSION_FAILED
-                OUTPUT_VARIABLE GIT_PKG_VERSION_FULL
-                ERROR_VARIABLE GIT_VERSION_ERROR
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-if(GIT_VERSION_FAILED)
-  message(
-    FATAL_ERROR
-      "Could not retrieve version from command 'git describe --tags'\n"
-      ${GIT_VERSION_ERROR})
-endif()
+if(VERSION_INFO)
+    set(SONATA_VERSION ${VERSION_INFO})
+else()
+    execute_process(COMMAND git describe --tags
+                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                    RESULT_VARIABLE GIT_VERSION_FAILED
+                    OUTPUT_VARIABLE GIT_PKG_VERSION_FULL
+                    ERROR_VARIABLE GIT_VERSION_ERROR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(GIT_VERSION_FAILED)
+      message(
+        FATAL_ERROR
+          "Could not retrieve version from command 'git describe --tags'\n"
+          ${GIT_VERSION_ERROR})
+    endif()
 # keep last line of command output
-string(REPLACE "\n"
-               ";"
-               GIT_PKG_VERSION_FULL
-               "${GIT_PKG_VERSION_FULL}")
-list(GET GIT_PKG_VERSION_FULL -1 GIT_PKG_VERSION_FULL)
+    string(REPLACE "\n"
+                   ";"
+                   GIT_PKG_VERSION_FULL
+                   "${GIT_PKG_VERSION_FULL}")
+    list(GET GIT_PKG_VERSION_FULL -1 GIT_PKG_VERSION_FULL)
 # keep MAJOR.MINOR.PATCH (PATCH being optional)
-string(REGEX
-       REPLACE "v?([0-9]+\\.[0-9]+(\\.[0-9]+)?).*"
-               "\\1"
-               SONATA_VERSION
-               "${GIT_PKG_VERSION_FULL}")
+    string(REGEX
+           REPLACE "v?([0-9]+\\.[0-9]+(\\.[0-9]+)?).*"
+                   "\\1"
+                   SONATA_VERSION
+                   "${GIT_PKG_VERSION_FULL}")
+endif()
 
 # Get "major.minor" from string "major.minor.version"
 string(REGEX MATCH "^(.*)\\.[^.]*$" dummy ${SONATA_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,19 +14,21 @@ if(NOT SONATA_VERSION)
           "Could not retrieve version from command 'git describe --tags'\n"
           ${GIT_VERSION_ERROR})
     endif()
+
 # keep last line of command output
     string(REPLACE "\n"
                    ";"
                    GIT_PKG_VERSION_FULL
                    "${GIT_PKG_VERSION_FULL}")
-    list(GET GIT_PKG_VERSION_FULL -1 GIT_PKG_VERSION_FULL)
-# keep MAJOR.MINOR.PATCH (PATCH being optional)
-    string(REGEX
-           REPLACE "v?([0-9]+\\.[0-9]+(\\.[0-9]+)?).*"
-                   "\\1"
-                   SONATA_VERSION
-                   "${GIT_PKG_VERSION_FULL}")
+   list(GET GIT_PKG_VERSION_FULL -1 SONATA_VERSION)
 endif()
+
+# keep MAJOR.MINOR.PATCH (PATCH being optional)
+string(REGEX
+       REPLACE "v?([0-9]+\\.[0-9]+(\\.[0-9]+)?).*"
+               "\\1"
+               SONATA_VERSION
+               "${SONATA_VERSION}")
 
 # Get "major.minor" from string "major.minor.version"
 string(REGEX MATCH "^(.*)\\.[^.]*$" dummy ${SONATA_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.3)
 cmake_policy(VERSION 3.3)
 
 execute_process(COMMAND git describe --tags
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                 RESULT_VARIABLE GIT_VERSION_FAILED
                 OUTPUT_VARIABLE GIT_PKG_VERSION_FULL
                 ERROR_VARIABLE GIT_VERSION_ERROR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,31 +2,29 @@ cmake_minimum_required(VERSION 3.3)
 cmake_policy(VERSION 3.3)
 
 # get version from Python package
-find_package(PythonInterp REQUIRED)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} setup.py --version
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                RESULT_VARIABLE PY_VERSION_FAILED
-                OUTPUT_VARIABLE PY_PKG_VERSION_FULL
-                ERROR_VARIABLE PY_VERSION_ERROR
+execute_process(COMMAND git describe --tags
+                RESULT_VARIABLE GIT_VERSION_FAILED
+                OUTPUT_VARIABLE GIT_PKG_VERSION_FULL
+                ERROR_VARIABLE GIT_VERSION_ERROR
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
-if(PY_VERSION_FAILED)
+if(GIT_VERSION_FAILED)
   message(
     FATAL_ERROR
-      "Could not retrieve version from command '${PYTHON_EXECUTABLE} setup.py --version'\n"
-      ${PY_VERSION_ERROR})
+      "Could not retrieve version from command 'git describe --tags'\n"
+      ${GIT_VERSION_ERROR})
 endif()
 # keep last line of command output
 string(REPLACE "\n"
                ";"
-               PY_PKG_VERSION_FULL
-               "${PY_PKG_VERSION_FULL}")
-list(GET PY_PKG_VERSION_FULL -1 PY_PKG_VERSION_FULL)
+               GIT_PKG_VERSION_FULL
+               "${GIT_PKG_VERSION_FULL}")
+list(GET GIT_PKG_VERSION_FULL -1 GIT_PKG_VERSION_FULL)
 # keep MAJOR.MINOR.PATCH (PATCH being optional)
 string(REGEX
-       REPLACE "([0-9]+\\.[0-9]+(\\.[0-9]+)?).*"
+       REPLACE "v?([0-9]+\\.[0-9]+(\\.[0-9]+)?).*"
                "\\1"
                SONATA_VERSION
-               "${PY_PKG_VERSION_FULL}")
+               "${GIT_PKG_VERSION_FULL}")
 
 # Get "major.minor" from string "major.minor.version"
 string(REGEX MATCH "^(.*)\\.[^.]*$" dummy ${SONATA_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.3)
 cmake_policy(VERSION 3.3)
 
-# get version from Python package
 execute_process(COMMAND git describe --tags
                 RESULT_VARIABLE GIT_VERSION_FAILED
                 OUTPUT_VARIABLE GIT_PKG_VERSION_FULL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.3)
 cmake_policy(VERSION 3.3)
 
-if(VERSION_INFO)
-    set(SONATA_VERSION ${VERSION_INFO})
-else()
+if(NOT SONATA_VERSION)
     execute_process(COMMAND git describe --tags
                     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                     RESULT_VARIABLE GIT_VERSION_FAILED

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ class CMakeBuild(build_ext, object):
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DEXTLIB_FROM_SUBMODULES=ON",
             "-DSONATA_PYTHON=ON",
+            "-DSONATA_VERSION=" + self.distribution.get_version(),
             "-DCMAKE_BUILD_TYPE=",
             "-DSONATA_CXX_WARNINGS=OFF",
             '-DPYTHON_EXECUTABLE=' + sys.executable


### PR DESCRIPTION
Would make our spack live easier. Should be equivalent to the old version detection.