### PR TITLE
Add __len__ attributes to python bindings.

### DIFF
--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -174,6 +174,11 @@ py::class_<Population, std::shared_ptr<Population>> bindPopulationClass(
             "Set of enumeration names"
         )
         .def(
+            "__len__",
+            &Population::size,
+            imbueElementName("Get the total number of {elem}s in the population").c_str()
+        )
+        .def(
             "enumeration_values",
             &Population::enumerationValues,
             py::arg("name"),

--- a/python/test.py
+++ b/python/test.py
@@ -45,6 +45,7 @@ class TestNodePopulation(unittest.TestCase):
 
     def test_size(self):
         self.assertEqual(self.test_obj.size, 6)
+        self.assertEqual(len(self.test_obj), 6)
 
     def test_attribute_names(self):
         self.assertEqual(


### PR DESCRIPTION
Fixes #48.