### PR TITLE
Adding move ctors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ matrix:
       python: 2.7
 
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       language: generic
       python: 3.6
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       language: generic
       python: 2.7
 

--- a/include/bbp/sonata/population.h
+++ b/include/bbp/sonata/population.h
@@ -207,6 +207,8 @@ protected:
 
     Population(const Population&) = delete;
 
+    Population(Population&&);
+
     virtual ~Population();
 
     struct Impl;
@@ -225,6 +227,8 @@ public:
     PopulationStorage(const std::string& h5FilePath, const std::string& csvFilePath = "");
 
     PopulationStorage(const PopulationStorage&) = delete;
+
+    PopulationStorage(PopulationStorage&&);
 
     ~PopulationStorage();
 

--- a/include/bbp/sonata/population.h
+++ b/include/bbp/sonata/population.h
@@ -207,9 +207,9 @@ protected:
 
     Population(const Population&) = delete;
 
-    Population(Population&&);
+    Population(Population&&) noexcept;
 
-    virtual ~Population();
+    virtual ~Population() noexcept;
 
     struct Impl;
     const std::unique_ptr<Impl> impl_;
@@ -228,9 +228,9 @@ public:
 
     PopulationStorage(const PopulationStorage&) = delete;
 
-    PopulationStorage(PopulationStorage&&);
+    PopulationStorage(PopulationStorage&&) noexcept;
 
-    ~PopulationStorage();
+    ~PopulationStorage() noexcept;
 
     /**
      * List all populations.

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -145,11 +145,11 @@ Population::Population(
 }
 
 
-Population::Population(Population&& p)
+Population::Population(Population&& p) noexcept
     : impl_(std::move(const_cast<std::unique_ptr<Population::Impl>&>(p.impl_))) {}
 
 
-Population::~Population() = default;
+Population::~Population() noexcept = default;
 
 
 std::string Population::name() const

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -145,6 +145,10 @@ Population::Population(
 }
 
 
+Population::Population(Population&& p)
+    : impl_(std::move(const_cast<std::unique_ptr<Population::Impl>&>(p.impl_))) {}
+
+
 Population::~Population() = default;
 
 

--- a/src/population.hpp
+++ b/src/population.hpp
@@ -198,14 +198,14 @@ PopulationStorage<Population>::PopulationStorage(const std::string& h5FilePath, 
 
 
 template <typename Population>
-PopulationStorage<Population>::PopulationStorage(PopulationStorage<Population>&& st)
+PopulationStorage<Population>::PopulationStorage(PopulationStorage<Population>&& st) noexcept
     : impl_(std::move(
         const_cast<std::unique_ptr<PopulationStorage<Population>::Impl>&>(st.impl_)))
 {}
 
 
 template<typename Population>
-PopulationStorage<Population>::~PopulationStorage() = default;
+PopulationStorage<Population>::~PopulationStorage() noexcept = default;
 
 
 template<typename Population>

--- a/src/population.hpp
+++ b/src/population.hpp
@@ -197,6 +197,13 @@ PopulationStorage<Population>::PopulationStorage(const std::string& h5FilePath, 
 }
 
 
+template <typename Population>
+PopulationStorage<Population>::PopulationStorage(PopulationStorage<Population>&& st)
+    : impl_(std::move(
+        const_cast<std::unique_ptr<PopulationStorage<Population>::Impl>&>(st.impl_)))
+{}
+
+
 template<typename Population>
 PopulationStorage<Population>::~PopulationStorage() = default;
 

--- a/tests/test_nodes.cpp
+++ b/tests/test_nodes.cpp
@@ -167,3 +167,10 @@ TEST_CASE("NodePopulation", "[base]")
     CHECK(population._dynamicsAttributeDataType("dparam-Y") == "int64_t");
     CHECK(population._dynamicsAttributeDataType("dparam-Z") == "string");
 }
+
+
+TEST_CASE("NodePopulationMove", "[base]") {
+    NodePopulation population("./data/nodes1.h5", "", "nodes-A");
+    NodePopulation pop2 = std::move(population);
+    CHECK(pop2.name() == "nodes-A");
+}


### PR DESCRIPTION
Libsonata is implemented using the pimpl idiom. Even though this idiom is know to have limitations, like being non-copyable, it does allow for move constructors. In fact move-constructing is extremely cheap since the only thing moved is the pointer.
A bit all around I see clients of this library using shared pointers due to the inability of moving.
This patch fixes that without any shortcoming.

**Implementation**
The move constructor has to be explicitly defined since the opaque pointer is const. Since data itself is non-const we can safely const_cast the pointer to move it.

**Tests**
A simple test was added where we move NodePopulation.