### PR TITLE
improve continuous integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 .tox/
 libsonata.cpython-*.so
 python/__pycache__/
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,24 +31,18 @@ cache:
 before_install:
   - rm -rf dist *.egg-info && python setup.py sdist
   - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install libhdf5-dev; else brew install hdf5; fi
-  - pip install --upgrade pip
-  - pip install virtualenv
-  - virtualenv env && source env/bin/activate
 
-install:
-  - pip install nose dist/*.tar.gz
-
+install: skip
 script:
-  - nosetests python &&
-    rm -rf build && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DEXTLIB_FROM_SUBMODULES=ON .. && make && make test
+  - ci/cpp_test.sh
+  - ci/python_test.sh
 
 
 deploy:
+  on:
+    tags: true
   provider: pypi
   user: bbp.opensource
   skip_existing: true
-  # Will be activated once I have verified that it is working
-  # on:
-  #   tags: true
   password:
     secure: "Es1muWW5O7DtgOznhQmgZmPjpFCeCE9lJjVM7mjXMeOO7ENRVHIssH3zLXewgBDrtSmaCPVO4SF1b2jO4kFOo3NV65b6+1tGcKnaN53VPbOF5Na5cevxZxY63znRy4y8P8PtTkuFS3JGx9x0KBuFyH+oT0t6J3JFCWyhV4EArDXbouNMLu+i2nL5fC8wl1TLWVA38zjbloqXwai4P3osJ/IRGkvmAW8na4g5ygovYTfFdCkGViTnnmJo1KITIin3rNgQHA/wghMH+lvEhYeis6fCfHPPV/1LMmVCEFi1lTmPimON4+zPP6WB9e/8jpoQCXivmkTuLsEvxVRiMfP5j06KjSMyjmSDKTSLaFUGnsykmcCU5vQAcy6WZNujnH6p0WfMrMRV9dR0oDs2QZIFfgbTHOWLZGI1jSujlR8goHlCFTIPd7fCjLJ4VqHAV+f2eTWLd1v//CXTAw1ivrwdIO4mBo6zGcH0rQRPDaY5xyspvmoX9RtsLugfnPYEePhI0xA+xU1GK/7BA738Yru8N9Q4zkOth4jVLHisN5p/gQuiu0j5WUCIfXp1CVgcFb6iiEQ83I0deI3rspcpK17OGqdanU9fWccRsxqFyqmQisWEexMLOlbKYKKatfP2PZR7wmCk8cYnL1A7GrBCEmcOCP460rmGHqsDfGyYo6FImFM="

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,7 @@
+Continuous Integration
+**********************
+
+Scripts related to continuous integration:
+
+* cpp_test.sh: c++ build and tests
+* python_test.sh: python build and tests

--- a/ci/cpp_test.sh
+++ b/ci/cpp_test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This file runs the C++ tests, as well as compiling the code with warnings on
+# so that errors should be caught quicker
+
+set -euxo pipefail
+
+rm -rf build
+mkdir build
+cd build
+cmake                           \
+    -DCMAKE_BUILD_TYPE=Release  \
+    -DEXTLIB_FROM_SUBMODULES=ON \
+    -DSONATA_PYTHON=ON          \
+    -DSONATA_CXX_WARNINGS=ON    \
+    ..
+make -j2
+make test

--- a/ci/cpp_test.sh
+++ b/ci/cpp_test.sh
@@ -11,7 +11,6 @@ cd build
 cmake                           \
     -DCMAKE_BUILD_TYPE=Release  \
     -DEXTLIB_FROM_SUBMODULES=ON \
-    -DSONATA_PYTHON=ON          \
     -DSONATA_CXX_WARNINGS=ON    \
     ..
 make -j2

--- a/ci/python_test.sh
+++ b/ci/python_test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+VENV=env
+
+pip install virtualenv
+rm -rf "$VENV"
+virtualenv "$VENV"
+
+set +u  # ignore errors in virtualenv's activate
+source "$VENV/bin/activate"
+set -u
+
+pip install --upgrade pip
+
+# install
+pip install .
+pip install nose
+nosetests python

--- a/include/bbp/sonata/population.h
+++ b/include/bbp/sonata/population.h
@@ -216,7 +216,8 @@ protected:
 };
 
 template <>
-std::vector<std::string> Population::getAttribute(const std::string& name, const Selection& selection) const;
+std::vector<std::string> Population::getAttribute<std::string>(
+    const std::string& name, const Selection& selection) const;
 
 //--------------------------------------------------------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,11 @@ class CMakeBuild(build_ext, object):
                 cmake_args += ["-A", "x64"]
             build_args += ["--", "/m"]
         else:
-            build_args += ["--", "-j"]
+            try:
+                CPU_COUNT = os.cpu_count()  # python 3.4+
+            except:
+                CPU_COUNT = 2
+            build_args += ["--", "-j%d" % CPU_COUNT]
 
         env = os.environ.copy()
         env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ class CMakeBuild(build_ext, object):
                 cmake_args += ["-A", "x64"]
             build_args += ["--", "/m"]
         else:
-            build_args += ["--", "-j".format(max(MIN_CPU_CORES, get_cpu_count()))]
+            build_args += ["--", "-j{}".format(max(MIN_CPU_CORES, get_cpu_count()))]
 
         env = os.environ.copy()
         env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import inspect
 import os
-import os.path as osp
 import platform
 import re
 import subprocess
@@ -14,6 +13,7 @@ from distutils.version import LooseVersion
 
 
 REQUIRED_NUMPY_VERSION = "numpy>=1.12.0"
+MIN_CPU_CORES = 2
 
 
 class lazy_dict(dict):
@@ -36,10 +36,22 @@ def get_sphinx_command():
     return BuildDoc
 
 
+def get_cpu_count():
+    try:
+        return len(os.sched_getaffinity(0))  # linux only
+    except:
+        pass
+
+    try:
+        return os.cpu_count()  # python 3.4+
+    except:
+        return 1  # default
+
+
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=""):
         Extension.__init__(self, name, sources=[])
-        self.sourcedir = osp.abspath(sourcedir)
+        self.sourcedir = os.path.abspath(sourcedir)
 
 
 class CMakeBuild(build_ext, object):
@@ -71,7 +83,7 @@ class CMakeBuild(build_ext, object):
             self.build_extension(ext)
 
     def build_extension(self, ext):
-        extdir = osp.abspath(osp.dirname(self.get_ext_fullpath(ext.name)))
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DEXTLIB_FROM_SUBMODULES=ON",
@@ -95,17 +107,13 @@ class CMakeBuild(build_ext, object):
                 cmake_args += ["-A", "x64"]
             build_args += ["--", "/m"]
         else:
-            try:
-                CPU_COUNT = os.cpu_count()  # python 3.4+
-            except:
-                CPU_COUNT = 2
-            build_args += ["--", "-j%d" % CPU_COUNT]
+            build_args += ["--", "-j%d" % max(MIN_CPU_CORES, get_cpu_count())]
 
         env = os.environ.copy()
         env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(
             env.get("CXXFLAGS", ""), self.distribution.get_version()
         )
-        if not osp.exists(self.build_temp):
+        if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
         subprocess.check_call(
             ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ class CMakeBuild(build_ext, object):
                 cmake_args += ["-A", "x64"]
             build_args += ["--", "/m"]
         else:
-            build_args += ["--", "-j%d" % max(MIN_CPU_CORES, get_cpu_count())]
+            build_args += ["--", "-j".format(max(MIN_CPU_CORES, get_cpu_count()))]
 
         env = os.environ.copy()
         env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -145,7 +145,7 @@ Population::Population(
 }
 
 
-Population::Population(Population&& p) noexcept = default;
+Population::Population(Population&&) noexcept = default;
 
 
 Population::~Population() noexcept = default;
@@ -193,8 +193,9 @@ std::vector<T> Population::getAttribute(const std::string& name, const Selection
 }
 
 
-template<>
-std::vector<std::string> Population::getAttribute(const std::string& name, const Selection& selection) const
+template <>
+std::vector<std::string> Population::getAttribute<std::string>(
+    const std::string& name, const Selection& selection) const
 {
     if (impl_->attributeEnumNames.count(name) == 0) {
         HDF5_LOCK_GUARD
@@ -312,9 +313,23 @@ INSTANTIATE_TEMPLATE_METHODS(uint64_t)
 INSTANTIATE_TEMPLATE_METHODS(size_t)
 #endif
 
-INSTANTIATE_TEMPLATE_METHODS(std::string)
-
 #undef INSTANTIATE_TEMPLATE_METHODS
+
+/* std:: string already has an Population::getAttribute(
+      const std::string& name, const Selection& selection) overload, so
+ * can't use the macro defined above, expand the rest by hand
+ */
+template std::vector<std::string> Population::getAttribute<std::string>( \
+    const std::string&, const Selection&, const std::string&) const; \
+template
+std::vector<std::string> Population::getEnumeration<std::string>(
+    const std::string&, const Selection&) const;
+template
+std::vector<std::string> Population::getDynamicsAttribute<std::string>(
+    const std::string&, const Selection&) const;
+template
+std::vector<std::string> Population::getDynamicsAttribute<std::string>(
+    const std::string&, const Selection&, const std::string&) const;
 
 //--------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
* move scripting from .travis.yaml to actual shell scripts
* setup.py on python 3.4 uses the correct number of cores available
  on the machine, otherwise 2 is used so less chance of freezing while
  compiling
* gitignore *.pyc