### PR TITLE
Make output of "python setup.py sdist" installable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v0.1.2: Fri Mar 13 2020
+## Development: v0.1.4
+
+### Fixed:
+
+ - Fixed python sdist distribution by disabling test requirements
+
+## v0.1.3: Fri Mar 13 2020
 
 ### Added:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ project(sonata VERSION ${SONATA_VERSION})
 
 option(EXTLIB_FROM_SUBMODULES "Use Git submodules for header-only dependencies" OFF)
 option(SONATA_PYTHON "Build Python extensions" OFF)
+option(SONATA_TESTS "Build tests" ON)
 option(${PROJECT_NAME}_CXX_WARNINGS "Compile C++ with warnings as errors" ON)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake)
@@ -171,17 +172,19 @@ install(EXPORT sonata-targets
 # Testing
 # =============================================================================
 
-enable_testing()
-add_subdirectory(tests)
+if (SONATA_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
 
-if (ENABLE_COVERAGE)
-    include(CodeCoverage)
-    set(COVERAGE_LCOV_EXCLUDES '/usr/*' '${PROJECT_SOURCE_DIR}/include/*' '${PROJECT_SOURCE_DIR}/extlib/*')
-    SETUP_TARGET_FOR_COVERAGE_LCOV(
-        NAME coverage
-        EXECUTABLE ctest
-        DEPENDENCIES unittests
-    )
+    if (ENABLE_COVERAGE)
+        include(CodeCoverage)
+        set(COVERAGE_LCOV_EXCLUDES '/usr/*' '${PROJECT_SOURCE_DIR}/include/*' '${PROJECT_SOURCE_DIR}/extlib/*')
+        SETUP_TARGET_FOR_COVERAGE_LCOV(
+            NAME coverage
+            EXECUTABLE ctest
+            DEPENDENCIES unittests
+        )
+    endif()
 endif()
 
 # =============================================================================

--- a/extlib/CMakeLists.txt
+++ b/extlib/CMakeLists.txt
@@ -7,4 +7,7 @@ target_link_libraries(HighFive INTERFACE
     ${HDF5_C_LIBRARIES})
 
 add_subdirectory(fmt)
-add_subdirectory(Catch2)
+
+if (SONATA_TESTS)
+    add_subdirectory(Catch2)
+endif()

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ class CMakeBuild(build_ext, object):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
+            "-DSONATA_TESTS={}".format(os.environ.get("SONATA_TESTS", "OFF")),
             "-DEXTLIB_FROM_SUBMODULES=ON",
             "-DSONATA_PYTHON=ON",
             "-DSONATA_VERSION=" + self.distribution.get_version(),


### PR DESCRIPTION
* Catch2 was previously a header only file, but that was
  changed to a submodule.  To save space in the source distribution,
  this isn't needed, so added a SONATA_TESTS CMake option to allow
  building without tests, and hence the Catch2 dependency