### PR TITLE
Expose Report data as Numpy

### DIFF
--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -23,7 +23,8 @@ struct SONATA_API DataFrame {
     std::vector<double> times;
     DataType ids;
     // data[times][ids]
-    std::vector<std::vector<float>> data;
+    size_t n_cols, n_rows;
+    std::vector<float> data;
 };
 
 using Spike = std::pair<NodeID, double>;

--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -22,8 +22,7 @@ struct SONATA_API DataFrame {
     using DataType = std::vector<KeyType>;
     std::vector<double> times;
     DataType ids;
-    // data[times][ids]
-    size_t n_cols, n_rows;
+    // data[times][ids], flattened. n_cols is ids.size()
     std::vector<float> data;
 };
 

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -322,7 +322,9 @@ void bindReportReader(py::module& m, const std::string& prefix) {
                                                   dframe.n_cols,
                                                   dframe.n_rows);
                                })
-        .def_readonly("times", &DataFrame<KeyType>::times);
+        .def_property_readonly("times", [](DataFrame<KeyType>& dframe) {
+            return asArray(std::move(dframe.times));
+        });
     py::class_<typename ReportType::Population>(m,
                                                 (prefix + "ReportPopulation").c_str(),
                                                 "A population inside a ReportReader")

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -51,6 +51,12 @@ py::array asArray(std::vector<std::string>&& values) {
     return py::array(py::dtype("object"), ptr->size(), ptr->data(), freeWhenDone(ptr));
 }
 
+template <typename T>
+py::array asArray(std::vector<T>&& values, ssize_t n_cols, ssize_t n_rows) {
+    auto ptr = new std::vector<T>(std::move(values));
+    return py::array({n_cols, n_rows}, ptr->data(), freeWhenDone(ptr));
+}
+
 
 template <typename T>
 py::object getAttribute(const Population& obj,
@@ -310,7 +316,7 @@ void bindReportReader(py::module& m, const std::string& prefix) {
                                    (prefix + "DataFrame").c_str(),
                                    "Something easily convertible to pandas dataframe")
         .def_readonly("ids", &DataFrame<KeyType>::ids)
-        .def_readonly("data", &DataFrame<KeyType>::data)
+        .def_property_readonly("data", [](DataFrame<KeyType>& dframe) { return asArray(std::move(dframe.data), dframe.n_cols, dframe.n_rows); })
         .def_readonly("times", &DataFrame<KeyType>::times);
     py::class_<typename ReportType::Population>(m,
                                                 (prefix + "ReportPopulation").c_str(),

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -62,6 +62,16 @@ py::array asArray(std::vector<T>&& values, ssize_t n_cols) {
 }
 
 
+// Return a new Numpy array with data owned by another python object
+// This avoids copies, and enables correct reference counting for memory keep-alive
+template <typename DATA_T, typename DIMS_T, typename OWNER_T>
+py::array managedMemoryArray(const DATA_T* data, const DIMS_T& dims, const OWNER_T& owner) {
+    const auto& tinfo = py::detail::get_type_info(typeid(OWNER_T));
+    const auto& handle = py::detail::get_object_handle(&owner, tinfo);
+    return py::array(dims, data, handle);
+}
+
+
 template <typename T>
 py::object getAttribute(const Population& obj,
                         const std::string& name,
@@ -314,18 +324,30 @@ struct type_caster<nonstd::nullopt_t>: public void_caster<nonstd::nullopt_t> {};
 }  // namespace detail
 }  // namespace pybind11
 
+
 template <typename ReportType, typename KeyType>
 void bindReportReader(py::module& m, const std::string& prefix) {
     py::class_<DataFrame<KeyType>>(m,
                                    (prefix + "DataFrame").c_str(),
-                                   "Something easily convertible to pandas dataframe")
+                                   "A container of raw reporting data, compatible with Pandas")
         .def_readonly("ids", &DataFrame<KeyType>::ids)
-        .def_property_readonly("data", [](DataFrame<KeyType>& dframe) {
-            return asArray(std::move(dframe.data), dframe.ids.size());
+
+        // .data and .time members are owned by this c++ object. We can't do std::move.
+        // To avoid copies we must declare the owner of the data is the current python
+        // object. Numpy will adjust owner reference count according to returned arrays
+        // clang-format off
+        .def_property_readonly("data", [](const DataFrame<KeyType>& dframe) {
+            std::array<ssize_t, 2> dims {0l, ssize_t(dframe.ids.size())};
+            if (dims[1] > 0) {
+                dims[0] = dframe.data.size() / dims[1];
+            }
+            return managedMemoryArray(dframe.data.data(), dims, dframe);
         })
+        // clang-format on
         .def_property_readonly("times", [](DataFrame<KeyType>& dframe) {
-            return asArray(std::move(dframe.times));
+            return managedMemoryArray(dframe.times.data(), dframe.times.size(), dframe);
         });
+
     py::class_<typename ReportType::Population>(m,
                                                 (prefix + "ReportPopulation").c_str(),
                                                 "A population inside a ReportReader")

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -52,16 +52,6 @@ py::array asArray(std::vector<std::string>&& values) {
 }
 
 
-// Return a 2D structure from a flat std::vector
-template <typename T>
-py::array asArray(std::vector<T>&& values, ssize_t n_cols) {
-    assert(values.size() % n_cols == 0);
-    const ssize_t n_rows = values.size() / n_cols;
-    auto ptr = new std::vector<T>(std::move(values));
-    return py::array({n_rows, n_cols}, ptr->data(), freeWhenDone(ptr));
-}
-
-
 // Return a new Numpy array with data owned by another python object
 // This avoids copies, and enables correct reference counting for memory keep-alive
 template <typename DATA_T, typename DIMS_T, typename OWNER_T>

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -316,7 +316,12 @@ void bindReportReader(py::module& m, const std::string& prefix) {
                                    (prefix + "DataFrame").c_str(),
                                    "Something easily convertible to pandas dataframe")
         .def_readonly("ids", &DataFrame<KeyType>::ids)
-        .def_property_readonly("data", [](DataFrame<KeyType>& dframe) { return asArray(std::move(dframe.data), dframe.n_cols, dframe.n_rows); })
+        .def_property_readonly("data",
+                               [](DataFrame<KeyType>& dframe) {
+                                   return asArray(std::move(dframe.data),
+                                                  dframe.n_cols,
+                                                  dframe.n_rows);
+                               })
         .def_readonly("times", &DataFrame<KeyType>::times);
     py::class_<typename ReportType::Population>(m,
                                                 (prefix + "ReportPopulation").c_str(),

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -29,6 +29,10 @@ static const char *__doc_bbp_sonata_DataFrame_data = R"doc()doc";
 
 static const char *__doc_bbp_sonata_DataFrame_ids = R"doc()doc";
 
+static const char *__doc_bbp_sonata_DataFrame_n_cols = R"doc()doc";
+
+static const char *__doc_bbp_sonata_DataFrame_n_rows = R"doc()doc";
+
 static const char *__doc_bbp_sonata_DataFrame_times = R"doc()doc";
 
 static const char *__doc_bbp_sonata_EdgePopulation = R"doc()doc";

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -29,10 +29,6 @@ static const char *__doc_bbp_sonata_DataFrame_data = R"doc()doc";
 
 static const char *__doc_bbp_sonata_DataFrame_ids = R"doc()doc";
 
-static const char *__doc_bbp_sonata_DataFrame_n_cols = R"doc()doc";
-
-static const char *__doc_bbp_sonata_DataFrame_n_rows = R"doc()doc";
-
 static const char *__doc_bbp_sonata_DataFrame_times = R"doc()doc";
 
 static const char *__doc_bbp_sonata_EdgePopulation = R"doc()doc";

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -301,6 +301,9 @@ class TestElementReportPopulation(unittest.TestCase):
 
     def test_get_reports_from_population(self):
         self.assertEqual(self.test_obj['All'].times, (0., 4., 0.2))
+        # check following calls succeed (no memory destroyed)
+        self.assertEqual(self.test_obj['All'].times, (0., 4., 0.2))
+
         self.assertEqual(self.test_obj['All'].time_units, 'ms')
         self.assertEqual(self.test_obj['All'].data_units, 'mV')
         self.assertTrue(self.test_obj['All'].sorted)
@@ -319,7 +322,7 @@ class TestElementReportPopulation(unittest.TestCase):
         self.assertEqual(len(sel.times), 3)  # Number of timestamp (0.8, 1.0 and 1.2)
         with self.assertRaises(SonataError): self.test_obj['All'].get(tstart=5.)  # tstart out of range
         self.test_obj['All'].get(tstart=3., tstop=3.) # tstart should be < tstop
-        np.testing.assert_allclose(np.array(self.test_obj['All'].get(node_ids=[3, 4], tstart=0.2, tstop=0.4).data[0]), [11.0, 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9], 1e-6, 0)
+        np.testing.assert_allclose(self.test_obj['All'].get(node_ids=[3, 4], tstart=0.2, tstop=0.4).data[0], [11.0, 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9], 1e-6, 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/report_reader.cpp
+++ b/src/report_reader.cpp
@@ -351,7 +351,8 @@ DataFrame<T> ReportReader<T>::Population::get(const nonstd::optional<Selection>&
     data_frame.n_rows = 0;
     for (const auto& node_id : node_ids) {
         const auto it = std::find_if(
-            nodes_pointers_.begin(), nodes_pointers_.end(),
+            nodes_pointers_.begin(),
+            nodes_pointers_.end(),
             [&node_id](const std::pair<NodeID, std::pair<NodeID, uint64_t>>& node_pointer) {
                 return node_pointer.first == node_id;
             });
@@ -364,7 +365,7 @@ DataFrame<T> ReportReader<T>::Population::get(const nonstd::optional<Selection>&
             .getDataSet("element_ids")
             .select({it->second.first}, {it->second.second - it->second.first})
             .read(element_ids);
-        for (const auto& elem: element_ids) {
+        for (const auto& elem : element_ids) {
             data_frame.ids.push_back(make_key<T>(node_id, elem));
         }
         data_frame.n_rows += element_ids.size();
@@ -396,7 +397,9 @@ DataFrame<T> ReportReader<T>::Population::get(const nonstd::optional<Selection>&
             .read(data);
         int timer_index = 0;
         for (const std::vector<float>& datum : data) {
-            std::copy(datum.data(), datum.data() + datum.size(), &data_frame.data[timer_index * data_frame.n_rows + ids_index]);
+            std::copy(datum.data(),
+                      datum.data() + datum.size(),
+                      &data_frame.data[timer_index * data_frame.n_rows + ids_index]);
             ++timer_index;
         }
         ids_index += data[0].size();

--- a/src/report_reader.cpp
+++ b/src/report_reader.cpp
@@ -278,7 +278,8 @@ std::vector<NodeID> ReportReader<T>::Population::getNodeIds() const {
 }
 
 template <typename T>
-std::pair<size_t, size_t> ReportReader<T>::Population::getIndex(const nonstd::optional<double>& tstart, const nonstd::optional<double>& tstop) const {
+std::pair<size_t, size_t> ReportReader<T>::Population::getIndex(
+    const nonstd::optional<double>& tstart, const nonstd::optional<double>& tstop) const {
     std::pair<size_t, size_t> indexes;
 
     const double start = tstart.value_or(tstart_);
@@ -354,8 +355,7 @@ DataFrame<T> ReportReader<T>::Population::get(const nonstd::optional<Selection>&
             nodes_pointers_.end(),
             [&node_id](const std::pair<NodeID, std::pair<NodeID, uint64_t>>& node_pointer) {
                 return node_pointer.first == node_id;
-            }
-        );
+            });
         if (it == nodes_pointers_.end()) {
             continue;
         }

--- a/tests/test_report_reader.cpp
+++ b/tests/test_report_reader.cpp
@@ -78,8 +78,7 @@ TEST_CASE("SomaReportReader", "[base]") {
     auto data = pop.get(Selection({{3, 5}}), 0.2, 0.5);
     REQUIRE(data.ids == DataFrame<NodeID>::DataType{{3, 4}});
     testTimes(data.times, 0.2, 0.1, 4);
-    REQUIRE(data.data == std::vector<std::vector<float>>{
-                             {{3.2f, 4.2f}, {3.3f, 4.3f}, {3.4f, 4.4f}, {3.5f, 4.5f}}});
+    REQUIRE(data.data == std::vector<float>{3.2f, 4.2f, 3.3f, 4.3f, 3.4f, 4.4f, 3.5f, 4.5f});
 }
 
 TEST_CASE("ElementReportReader limits", "[base]") {
@@ -132,11 +131,9 @@ TEST_CASE("ElementReportReader", "[base]") {
                 {{3, 5}, {3, 5}, {3, 6}, {3, 6}, {3, 7}, {4, 7}, {4, 8}, {4, 8}, {4, 9}, {4, 9}}});
     testTimes(data.times, 0.2, 0.2, 2);
     REQUIRE(data.data ==
-            std::vector<std::vector<float>>{
-                {{11.0f, 11.1f, 11.2f, 11.3f, 11.4f, 11.5f, 11.6f, 11.7f, 11.8f, 11.9f},
-                 {21.0f, 21.1f, 21.2f, 21.3f, 21.4f, 21.5f, 21.6f, 21.7f, 21.8f, 21.9f}}});
+            std::vector<float>{11.0f, 11.1f, 11.2f, 11.3f, 11.4f, 11.5f, 11.6f, 11.7f, 11.8f, 11.9f, 21.0f, 21.1f, 21.2f, 21.3f, 21.4f, 21.5f, 21.6f, 21.7f, 21.8f, 21.9f});
 
     // Select only one time
     REQUIRE(pop.get(Selection({{1, 2}}), 0.6, 0.6).data ==
-            std::vector<std::vector<float>>{{{30.0f, 30.1f, 30.2f, 30.3f, 30.4f}}});
+            std::vector<float>{30.0f, 30.1f, 30.2f, 30.3f, 30.4f});
 }

--- a/tests/test_report_reader.cpp
+++ b/tests/test_report_reader.cpp
@@ -130,8 +130,9 @@ TEST_CASE("ElementReportReader", "[base]") {
             DataFrame<std::pair<NodeID, ElementID>>::DataType{
                 {{3, 5}, {3, 5}, {3, 6}, {3, 6}, {3, 7}, {4, 7}, {4, 8}, {4, 8}, {4, 9}, {4, 9}}});
     testTimes(data.times, 0.2, 0.2, 2);
-    REQUIRE(data.data ==
-            std::vector<float>{11.0f, 11.1f, 11.2f, 11.3f, 11.4f, 11.5f, 11.6f, 11.7f, 11.8f, 11.9f, 21.0f, 21.1f, 21.2f, 21.3f, 21.4f, 21.5f, 21.6f, 21.7f, 21.8f, 21.9f});
+    REQUIRE(data.data == std::vector<float>{11.0f, 11.1f, 11.2f, 11.3f, 11.4f, 11.5f, 11.6f,
+                                            11.7f, 11.8f, 11.9f, 21.0f, 21.1f, 21.2f, 21.3f,
+                                            21.4f, 21.5f, 21.6f, 21.7f, 21.8f, 21.9f});
 
     // Select only one time
     REQUIRE(pop.get(Selection({{1, 2}}), 0.6, 0.6).data ==


### PR DESCRIPTION
## The problem
The `DataFrame` struct contains the Report data following a query. These can be long vectors, and default Pybind11 interface is a list. Converting such data to list, besides heavy in memory and processing, requires subsequent conversion to numpy or Pandas to be efficiently handled.

## This PR
Exposes the larger `.times` and `.data` vectors as Numpy arrays, without copies. 
Initial attempt was using the `asArray` method. However it steals the memory from the struct, which is not acceptable as subsequent requests for the vector would fail.
Second attempt was using memory-views. Although simple and functional, this approach suffered from the fact that memory views have a rudimentary API and therefore would require later conversion to numpy. Besides, when deleting the struct object the memory view would go invalid.
Third and clean option is to return a Numpy array with the custom handle. In case the handle is a python object, numpy will automatically adjust reference counting on that object, the owner of the data, in this case the struct. It is a perfect fit, however, to retrieve the python object from the current C++ object one requires internal API. A new helper function `managedMemoryArray` was created to return such arrays.