### PR TITLE
Add __repr__ to python Selection binding

### DIFF
--- a/.github/workflows/docstring_check.yaml
+++ b/.github/workflows/docstring_check.yaml
@@ -14,7 +14,7 @@ jobs:
         - name: Install packages
           run: sudo apt-get update && sudo apt-get install build-essential libhdf5-dev python3-venv libclang1-9
         - name: Add pybind11 tools to path
-          run: echo "::set-env name=PYTHONPATH::/home/runner/work/libsonata/libsonata/python/pybind11/tools"
+          run: echo "PYTHONPATH=/home/runner/work/libsonata/libsonata/python/pybind11/tools" >> $GITHUB_ENV
         - name: Set libclang symlink
           run: |
             cd /usr/lib/x86_64-linux-gnu

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -10,6 +10,7 @@
 #include "generated/docstrings.h"
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <cstdint>
 #include <memory>
@@ -178,6 +179,10 @@ py::class_<Population, std::shared_ptr<Population>> bindPopulationClass(py::modu
                                &Population::enumerationNames,
                                DOC_POP(enumerationNames))
         .def("__len__", &Population::size, imbueElementName(DOC_POP(size)).c_str())
+        .def("__repr__",
+             [clsName](Population& obj) {
+                 return fmt::format("{} [name={}, count={}]", clsName, obj.name(), obj.size());
+             })
         .def("select_all", &Population::selectAll, imbueElementName(DOC_POP(selectAll)).c_str())
         .def("enumeration_values",
              &Population::enumerationValues,
@@ -393,7 +398,19 @@ PYBIND11_MODULE(_libsonata, m) {
         .def("__eq__", &bbp::sonata::operator==, "Compare selection contents are equal")
         .def("__ne__", &bbp::sonata::operator!=, "Compare selection contents are not equal")
         .def("__or__", &bbp::sonata::operator|, "Union of selections")
-        .def("__and__", &bbp::sonata::operator&, "Intersection of selections");
+        .def("__and__", &bbp::sonata::operator&, "Intersection of selections")
+        .def("__repr__", [](Selection& obj) {
+            const auto ranges = obj.ranges();
+            const size_t max_count = 10;
+
+            if (ranges.size() < max_count) {
+                return fmt::format("Selection([{}])", fmt::join(ranges, ", "));
+            }
+
+            return fmt::format("Selection([{}, ..., {}])",
+                               fmt::join(ranges.begin(), ranges.begin() + 3, ", "),
+                               fmt::join(ranges.end() - 3, ranges.end(), ", "));
+        });
     py::implicitly_convertible<py::list, Selection>();
     py::implicitly_convertible<py::tuple, Selection>();
 


### PR DESCRIPTION
Ex:
    python -c 'from libsonata import Selection; print(Selection([(15, 16), (10, 11)]))'
    -> Selection([(15, 16), (10, 11)])

    python -c 'from libsonata import Selection; print(Selection(range(0, 100, 2)))'
    -> Selection([(0, 1), (2, 3), (4, 5), ..., (94, 95), (96, 97), (98, 99)])

* use new environment setting post CVE-2020--15228
* fixes #69