### PR TITLE
lookup vector of values in matchAttributeValues

### DIFF
--- a/include/bbp/sonata/nodes.h
+++ b/include/bbp/sonata/nodes.h
@@ -46,6 +46,13 @@ class SONATA_API NodePopulation: public Population
      */
     template <typename T>
     Selection matchAttributeValues(const std::string& attribute, const T value) const;
+
+    /**
+     * Like matchAttributeValues, but for vectors of values to match
+     */
+    template <typename T>
+    Selection matchAttributeValues(const std::string& attribute,
+                                   const std::vector<T>& values) const;
 };
 
 //--------------------------------------------------------------------------------------------------

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -73,6 +73,8 @@ Throws:
 
 Note: This does not match dynamics_params datasets)doc";
 
+static const char *__doc_bbp_sonata_NodePopulation_matchAttributeValues_2 = R"doc(Like matchAttributeValues, but for vectors of values to match)doc";
+
 static const char *__doc_bbp_sonata_NodeSets = R"doc()doc";
 
 static const char *__doc_bbp_sonata_NodeSets_NodeSets =

--- a/src/node_sets.cpp
+++ b/src/node_sets.cpp
@@ -122,11 +122,7 @@ class NodeSetBasicRule: public NodeSetRule
 
     Selection materialize(const detail::NodeSets& /* unused */,
                           const NodePopulation& np) const final {
-        Selection ret{{}};
-        for (const auto& v : values_) {
-            ret = ret | np.matchAttributeValues(attribute_, v);
-        }
-        return ret;
+        return np.matchAttributeValues(attribute_, values_);
     }
 
     std::string toJSON() const final {


### PR DESCRIPTION
* when several values are to be tested against the whole vector,
  only load the vector once, and compare each instance against the
  wanted list

* for nodeset with multiple values:
    ex:
        "L23": {
           "mtype": [ "L23_BP", "L23_BTC", "L23_CHC", "L23_DBC", "L23_LBC",
                      "L23_MC", "L23_NBC", "L23_NGC", "L23_SBC", "L2_IPC",
                      "L2_TPC:A", "L2_TPC:B", "L3_TPC:A", "L3_TPC:C"]
        }
    The old code takes about ~78ms to match 1177860 of 4234929 elements,
    and the new takes ~63ms.

* for nodeset with a single value:
    ex:
        "L23_BP": { "mtype": "L23_BP" }
    The old code takes about ~7ms to match 9599 of 4234929 elements,
    and the new takes ~8ms.

    and:
        "EXC": { "synapse_class": "EXC" }
    The old code takes about ~15ms to match 3738444 of 4234929 elements,
    and the new takes ~16ms.