### PR TITLE
have CI work for internal/external PRs and pushes

### DIFF
--- a/.github/workflows/clang_format_check.yaml
+++ b/.github/workflows/clang_format_check.yaml
@@ -5,6 +5,9 @@ jobs:
   build:
     name: clang-format-check
     runs-on: ubuntu-18.04
+    # Run on external PRs, but not internal PRs as they'll be run by the push
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     steps:
         - name: Fetch repository
           uses: actions/checkout@v1

--- a/.github/workflows/coverage_test.yaml
+++ b/.github/workflows/coverage_test.yaml
@@ -1,13 +1,13 @@
 name: coverage-test
-on:
-    push:
-      branches:
-        - master
+on: [pull_request, push]
 
 jobs:
     build:
         name: coverage-test
         runs-on: ubuntu-18.04
+        # Run on external PRs, but not internal PRs as they'll be run by the push
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
         steps:
             - name: Checkout repository
               uses: actions/checkout@v2

--- a/.github/workflows/docstring_check.yaml
+++ b/.github/workflows/docstring_check.yaml
@@ -5,6 +5,9 @@ jobs:
   build:
     name: docstring-check
     runs-on: ubuntu-18.04
+    # Run on external PRs, but not internal PRs as they'll be run by the push
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     steps:
         - name: Fetch repository
           uses: actions/checkout@v2.1.0


### PR DESCRIPTION
* 'external' PRs (ie: not part of the BlueBrain org) run CI
* avoid running CI twice for 'internal' PRs
* have CI run on all pushes