### PR TITLE
Replaces binding of compartment ids for std::array<uint64_t,2>

### DIFF
--- a/include/bbp/sonata/common.h
+++ b/include/bbp/sonata/common.h
@@ -41,7 +41,7 @@ using NodeID = uint64_t;
 using EdgeID = uint64_t;
 using ElementID = uint32_t;
 // For performance reasons and to ease the Python bindings, the definition of
-// CompartmentID is no longer an std::pair<typeof(NodeID), typeof(ElementID)> 
+// CompartmentID is no longer an std::pair<typeof(NodeID), typeof(ElementID)>
 using CompartmentID = std::array<uint64_t, 2>;
 
 class SONATA_API SonataError: public std::runtime_error

--- a/include/bbp/sonata/common.h
+++ b/include/bbp/sonata/common.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <stdexcept>
 
@@ -39,6 +40,7 @@ SONATA_API const std::string version();
 using NodeID = uint64_t;
 using EdgeID = uint64_t;
 using ElementID = uint32_t;
+using CompartmentID = std::array<uint64_t, 2>;
 
 class SONATA_API SonataError: public std::runtime_error
 {

--- a/include/bbp/sonata/common.h
+++ b/include/bbp/sonata/common.h
@@ -40,6 +40,8 @@ SONATA_API const std::string version();
 using NodeID = uint64_t;
 using EdgeID = uint64_t;
 using ElementID = uint32_t;
+// For performance reasons and to ease the Python bindings, the definition of
+// CompartmentID is no longer an std::pair<typeof(NodeID), typeof(ElementID)> 
 using CompartmentID = std::array<uint64_t, 2>;
 
 class SONATA_API SonataError: public std::runtime_error

--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -16,7 +16,7 @@ namespace H5 = HighFive;
 namespace bbp {
 namespace sonata {
 
-// KeyType will be NodeID for somas report and pair<NodeID, ElementID> for elements report
+// KeyType will be NodeID for somas report and CompartmentID for elements report
 template <typename KeyType>
 struct SONATA_API DataFrame {
     using DataType = std::vector<KeyType>;
@@ -170,7 +170,7 @@ class SONATA_API ReportReader
 };
 
 using SomaReportReader = ReportReader<NodeID>;
-using ElementReportReader = ReportReader<std::pair<NodeID, ElementID>>;
+using ElementReportReader = ReportReader<CompartmentID>;
 
 }  // namespace sonata
 }  // namespace bbp

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -330,12 +330,14 @@ void bindReportReader(py::module& m, const std::string& prefix) {
     py::class_<DataFrame<KeyType>>(m,
                                    (prefix + "DataFrame").c_str(),
                                    "A container of raw reporting data, compatible with Pandas")
-        .def_readonly("ids", &DataFrame<KeyType>::ids)
-
-        // .data and .time members are owned by this c++ object. We can't do std::move.
-        // To avoid copies we must declare the owner of the data as the current python
+        // .ids, .data and .time members are owned by the c++ object. We can't do std::move.
+        // To avoid copies, we must declare the owner of the data as the current Python
         // object. Numpy will adjust owner reference count according to returned arrays
         // clang-format off
+        .def_property_readonly("ids", [](const DataFrame<KeyType>& dframe) {
+            std::array<ssize_t, 1> dims { ssize_t(dframe.ids.size()) };
+            return managedMemoryArray(dframe.ids.data(), dims, dframe);
+        })
         .def_property_readonly("data", [](const DataFrame<KeyType>& dframe) {
             std::array<ssize_t, 2> dims {0l, ssize_t(dframe.ids.size())};
             if (dims[1] > 0) {
@@ -622,7 +624,7 @@ PYBIND11_MODULE(_libsonata, m) {
         .def("__getitem__", &SpikeReader::openPopulation);
 
     bindReportReader<SomaReportReader, NodeID>(m, "Soma");
-    bindReportReader<ElementReportReader, std::pair<NodeID, uint32_t>>(m, "Element");
+    bindReportReader<ElementReportReader, CompartmentID>(m, "Element");
 
     py::register_exception<SonataError>(m, "SonataError");
 }

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -316,11 +316,15 @@ class TestSomaReportPopulation(unittest.TestCase):
 
         sel = self.test_obj['All'].get(node_ids=[13, 14], tstart=0.8, tstop=1.0)
         self.assertEqual(len(sel.times), 2)  # Number of timestamp (0.8 and 0.9)
-        self.assertEqual(list(sel.ids), [13, 14])
+        keys = sel.ids
+        keys_ref = np.asarray([13, 14])
+        self.assertTrue((keys == keys_ref).all())
         np.testing.assert_allclose(sel.data, [[13.8, 14.8], [13.9, 14.9]])
 
         sel_all = self.test_obj['All'].get()
-        self.assertEqual(sel_all.ids, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+        keys_all = sel_all.ids
+        keys_all_ref = np.asarray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+        self.assertTrue((keys_all == keys_all_ref).all())
 
         sel_empty = self.test_obj['All'].get(node_ids=[])
         np.testing.assert_allclose(sel_empty.data, np.empty(shape=(0, 0)))
@@ -355,10 +359,9 @@ class TestElementReportPopulation(unittest.TestCase):
         self.assertEqual(len(self.test_obj['All'].get(tstride=2).times), 10)  # Should be the same
         self.assertEqual(len(self.test_obj['All'].get().ids), 100)
         sel = self.test_obj['All'].get(node_ids=[13, 14], tstart=0.8, tstop=1.2)
-        keys = list(sel.ids)
-        keys.sort()
-        self.assertEqual(keys, [(13, 30), (13, 30), (13, 31), (13, 31), (13, 32), (14, 32), (14, 33), (14, 33), (14, 34), (14, 34)])
-
+        keys = sel.ids
+        keys_ref = np.asarray([(13, 30), (13, 30), (13, 31), (13, 31), (13, 32), (14, 32), (14, 33), (14, 33), (14, 34), (14, 34)])
+        self.assertTrue((keys == keys_ref).all())
         self.assertEqual(len(self.test_obj['All'].get(node_ids=[]).data), 0)
         self.assertEqual(len(self.test_obj['All'].get(node_ids=[]).times), 0)
         self.assertEqual(len(self.test_obj['All'].get(node_ids=[]).ids), 0)

--- a/src/report_reader.cpp
+++ b/src/report_reader.cpp
@@ -15,6 +15,7 @@ HIGHFIVE_REGISTER_TYPE(bbp::sonata::SpikeReader::Population::Sorting, create_enu
 
 namespace {
 
+using bbp::sonata::CompartmentID;
 using bbp::sonata::ElementID;
 using bbp::sonata::NodeID;
 using bbp::sonata::Selection;
@@ -86,7 +87,7 @@ NodeID make_key(NodeID node_id, ElementID /* element_id */) {
 }
 
 template <>
-std::pair<NodeID, ElementID> make_key(NodeID node_id, ElementID element_id) {
+CompartmentID make_key(NodeID node_id, ElementID element_id) {
     return {node_id, element_id};
 }
 
@@ -419,7 +420,7 @@ DataFrame<T> ReportReader<T>::Population::get(const nonstd::optional<Selection>&
 }
 
 template class ReportReader<NodeID>;
-template class ReportReader<std::pair<NodeID, ElementID>>;
+template class ReportReader<CompartmentID>;
 
 }  // namespace sonata
 }  // namespace bbp

--- a/tests/test_report_reader.cpp
+++ b/tests/test_report_reader.cpp
@@ -101,7 +101,7 @@ TEST_CASE("ElementReportReader limits", "[base]") {
 
     // ids out of range
     REQUIRE(pop.get(Selection({{100, 101}})).ids ==
-            DataFrame<std::pair<NodeID, ElementID>>::DataType{});
+            DataFrame<CompartmentID>::DataType{});
 
     // Inverted id
     REQUIRE_THROWS(pop.get(Selection({{2, 1}})));
@@ -143,7 +143,7 @@ TEST_CASE("ElementReportReader", "[base]") {
 
     auto data = pop.get(Selection({{3, 5}}), 0.2, 0.5);
     REQUIRE(data.ids ==
-            DataFrame<std::pair<NodeID, ElementID>>::DataType{
+            DataFrame<CompartmentID>::DataType{
                 {{3, 5}, {3, 5}, {3, 6}, {3, 6}, {3, 7}, {4, 7}, {4, 8}, {4, 8}, {4, 9}, {4, 9}}});
     testTimes(data.times, 0.2, 0.2, 2);
     REQUIRE(data.data == std::vector<float>{11.0f, 11.1f, 11.2f, 11.3f, 11.4f, 11.5f, 11.6f,


### PR DESCRIPTION
Using `py-bluepy`, we observed recently that the `ids` of a compartment report were mapped into a Python list of tuples instead of returning a pointer to the actual data in the bindings. This PR solves this issue by correctly returning an `numpy.ndarray`, which can be used automatically by `py-bluepy` without further changes.

For instance, retrieving a single row of a reference dataset that contains close to 80 million columns per timestep, takes the following:
```
Without fix: 147.01s
With fix: 13.44s
```
Any of the operations that involve the `ids` incur in large data conversions, increasing the execution times. One example is `len(view.ids)` inside `py-bluepy`, that required close to 30 seconds.

Further details of the on-going investigations are available in HPCTM-1487.

Co-authored with @jorblancoa, @matz-e, and @alkino.