### PR TITLE
Add getTimes inside SpikeReader::Population

### DIFF
--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -52,6 +52,11 @@ class SONATA_API SpikeReader
         };
 
         /**
+         * Return (tstart, tstop) of the population
+         */
+        std::tuple<double, double> getTimes() const;
+
+        /**
          * Return reports for this population.
          */
         Spikes get(const nonstd::optional<Selection>& node_ids = nonstd::nullopt,

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -614,7 +614,10 @@ PYBIND11_MODULE(_libsonata, m) {
                     return "by_time";
                 return "none";
             },
-            DOC_SPIKEREADER_POP(getSorting));
+            DOC_SPIKEREADER_POP(getSorting))
+        .def_property_readonly("times",
+                               &SpikeReader::Population::getTimes,
+                               DOC_SPIKEREADER_POP(getTimes));
     py::class_<SpikeReader>(m, "SpikeReader", "Used to read spike files")
         .def(py::init([](py::object h5_filepath) { return SpikeReader(py::str(h5_filepath)); }),
              "h5_filepath"_a)

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -518,6 +518,8 @@ static const char *__doc_bbp_sonata_SpikeReader_Population_get = R"doc(Return re
 
 static const char *__doc_bbp_sonata_SpikeReader_Population_getSorting = R"doc(Return the way data are sorted ('none', 'by_id', 'by_time'))doc";
 
+static const char *__doc_bbp_sonata_SpikeReader_Population_getTimes = R"doc(Return (tstart, tstop) of the population)doc";
+
 static const char *__doc_bbp_sonata_SpikeReader_Population_sorting = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SpikeReader_Population_spikes = R"doc()doc";

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -291,6 +291,9 @@ class TestSpikePopulation(unittest.TestCase):
 
         self.assertEqual(len(self.test_obj['All'].get(node_ids=[])), 0)
 
+    def test_getTimes_from_population(self):
+        self.assertEqual(self.test_obj['All'].times, (0.1, 1.3))
+
 class TestSomaReportPopulation(unittest.TestCase):
     def setUp(self):
         path = os.path.join(PATH, "somas.h5")

--- a/src/report_reader.cpp
+++ b/src/report_reader.cpp
@@ -112,6 +112,10 @@ auto SpikeReader::openPopulation(const std::string& populationName) const -> con
     return populations_.at(populationName);
 }
 
+std::tuple<double, double> SpikeReader::Population::getTimes() const {
+    return std::tie(tstart_, tstop_);
+}
+
 Spikes SpikeReader::Population::get(const nonstd::optional<Selection>& node_ids,
                                     const nonstd::optional<double>& tstart,
                                     const nonstd::optional<double>& tstop) const {

--- a/tests/test_report_reader.cpp
+++ b/tests/test_report_reader.cpp
@@ -33,6 +33,8 @@ TEST_CASE("SpikeReader", "[base]") {
     REQUIRE(reader.openPopulation("All").get(Selection({{5, 6}}), 0.1, 0.1) ==
             std::vector<std::pair<uint64_t, double>>{{5, 0.1}});
     REQUIRE(reader.openPopulation("empty").get() == std::vector<std::pair<uint64_t, double>>{});
+
+    REQUIRE(reader.openPopulation("All").getTimes() == std::make_tuple(0.1, 1.3));
 }
 
 TEST_CASE("SomaReportReader limits", "[base]") {


### PR DESCRIPTION
Return start and stop times.

Fix #155 