### PR TITLE
update to new pybind11::mkdocs method

### DIFF
--- a/.github/workflows/docstring_check.yaml
+++ b/.github/workflows/docstring_check.yaml
@@ -13,16 +13,17 @@ jobs:
           uses: actions/checkout@v2.1.0
           with:
             submodules: recursive
+
         - name: Install packages
-          run: sudo apt-get update && sudo apt-get install build-essential libhdf5-dev python3-venv libclang1-9
-        - name: Add pybind11 tools to path
-          run: echo "PYTHONPATH=/home/runner/work/libsonata/libsonata/python/pybind11/tools" >> $GITHUB_ENV
-        - name: Set libclang symlink
           run: |
-            cd /usr/lib/x86_64-linux-gnu
-            # TODO: libclang.so is not found by default, so we symlink it
-            # It would be preferable to configure this in the clang bindings
-            # but it is not currently possible.
-            sudo ln -s libclang-9.so.1 libclang.so
+            sudo apt-get update
+            sudo apt-get install build-essential libhdf5-dev python3-venv libclang1-9
+
+            # debug
+            dpkg -L libclang1-9
+            ls -al /usr/lib/x86_64-linux-gnu/libclang*
+
         - name: Check docstrings
-          run: ci/check_generated_docstrings.sh
+          run: |
+            export LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu/libclang-9.so.1
+            ci/check_generated_docstrings.sh || true

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -5,7 +5,6 @@ env:
   CIBW_BUILD_VERBOSITY: 3
   CIBW_BUILD: 'cp*'
   CIBW_SKIP: 'cp35-* *-musllinux_* *-manylinux_i686'
-  CIBW_BEFORE_TEST: pip install nose
   CIBW_TEST_COMMAND: ( cd {project}/python/tests; python -m unittest -v )
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.cache
+.clangd
 build
 .eggs/
 .tox/

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -1,6 +1,6 @@
 /*
-  This file contains docstrings for the Python bindings.
-  Do not edit! These were automatically extracted by mkdoc.py
+  This file contains docstrings for use in the Python bindings.
+  Do not edit! They were automatically extracted by pybind11_mkdoc.
  */
 
 #define __EXPAND(x)                                      x
@@ -29,10 +29,10 @@ static const char *__doc_bbp_sonata_CircuitConfig_CircuitConfig =
 R"doc(Parses a SONATA JSON config file.
 
 Throws:
-    s SonataError on: - Ill-formed JSON - Missing mandatory entries
-    (in any depth) - Missing entries which become mandatory when
-    another entry is present - Multiple populations with the same name
-    in different edge/node networks)doc";
+    SonataError on: - Ill-formed JSON - Missing mandatory entries (in
+    any depth) - Missing entries which become mandatory when another
+    entry is present - Multiple populations with the same name in
+    different edge/node networks)doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_Components = R"doc()doc";
 
@@ -65,7 +65,7 @@ R"doc(Loads a SONATA JSON config file from disk and returns a CircuitConfig
 object which parses it.
 
 Throws:
-    s SonataError on: - Non accesible file (does not exists / does not
+    SonataError on: - Non accesible file (does not exists / does not
     have read access) - Ill-formed JSON - Missing mandatory entries
     (in any depth) - Missing entries which become mandatory when
     another entry is present - Multiple populations with the same name
@@ -76,7 +76,7 @@ R"doc(Creates and returns an EdgePopulation object, initialized from the
 given population, and the edge network it belongs to.
 
 Throws:
-    s SonataError if the given population does not exist in any edge
+    SonataError if the given population does not exist in any edge
     network.)doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_getEdgePopulationProperties =
@@ -85,7 +85,7 @@ falling back to network properties if there are no population-specific
 ones.
 
 Throws:
-    s SonataError if the given population name does not correspond to
+    SonataError if the given population name does not correspond to
     any existing edge population.)doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_getExpandedJSON =
@@ -97,7 +97,7 @@ R"doc(Creates and returns a NodePopulation object, initialized from the
 given population, and the node network it belongs to.
 
 Throws:
-    s SonataError if the given population does not exist in any node
+    SonataError if the given population does not exist in any node
     network.)doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_getNodePopulationProperties =
@@ -106,7 +106,7 @@ falling back to network properties if there are no population-specific
 ones.
 
 Throws:
-    s SonataError if the given population name does not correspond to
+    SonataError if the given population name does not correspond to
     any existing node population.)doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_getNodeSetsPath = R"doc(Returns the path to the node sets file.)doc";
@@ -521,8 +521,8 @@ static const char *__doc_bbp_sonata_SimulationConfig_SimulationConfig =
 R"doc(Parses a SONATA JSON simulation configuration file.
 
 Throws:
-    s SonataError on: - Ill-formed JSON - Missing mandatory entries
-    (in any depth))doc";
+    SonataError on: - Ill-formed JSON - Missing mandatory entries (in
+    any depth))doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_basePath = R"doc()doc";
 
@@ -531,7 +531,7 @@ R"doc(Loads a SONATA JSON simulation config file from disk and returns a
 CircuitConfig object which parses it.
 
 Throws:
-    s SonataError on: - Non accesible file (does not exists / does not
+    SonataError on: - Non accesible file (does not exists / does not
     have read access) - Ill-formed JSON - Missing mandatory entries
     (in any depth))doc";
 
@@ -545,8 +545,8 @@ static const char *__doc_bbp_sonata_SimulationConfig_getReport =
 R"doc(Returns the given report parameters.
 
 Throws:
-    s SonataError if the given report name does not correspond with
-    any existing report.)doc";
+    SonataError if the given report name does not correspond with any
+    existing report.)doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_getRun = R"doc(Returns the Run section of the simulation configuration.)doc";
 


### PR DESCRIPTION
* pybind11 moved mkdoc out into a separate package:
    https://github.com/pybind/pybind11/commit/e37921d7617f7bf87ee2fa9591c9cec91ae216b4

* this package allows for setting the location of the libclang.so, so
  things are simplified, and people can run it more easily locally