### PR TITLE
Changes how the ids and positions are retrieved

### DIFF
--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -98,9 +98,9 @@ class SONATA_API SpikeReader
     mutable std::map<std::string, Population> populations_;
 };
 
-  using Range = std::pair<uint64_t, uint64_t>;
-  using Ranges = std::vector<Range>;
-  using NodePointers = std::map<NodeID, Range>;
+using Range = std::pair<uint64_t, uint64_t>;
+using Ranges = std::vector<Range>;
+using NodePointers = std::map<NodeID, Range>;
 
 template <typename KeyType>
 class SONATA_API ReportReader
@@ -166,6 +166,10 @@ class SONATA_API ReportReader
         Population(const H5::File& file, const std::string& populationName);
         std::pair<size_t, size_t> getIndex(const nonstd::optional<double>& tstart,
                                            const nonstd::optional<double>& tstop) const;
+        std::pair<NodePointers, Range> getNodePointers(
+            const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
+        typename DataFrame<KeyType>::DataType getElementIds(const NodePointers& node_pointers,
+                                                            const Range& range) const;
 
         NodePointers nodes_pointers_;
         H5::Group pop_group_;
@@ -175,10 +179,6 @@ class SONATA_API ReportReader
         std::string time_units_;
         std::string data_units_;
         bool nodes_ids_sorted_ = false;
-        std::pair<NodePointers, Range> node_pointers_from_selection(
-            const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
-        typename DataFrame<KeyType>::DataType ids_from_node_pointers(
-            const std::pair<NodePointers, Range>& result) const;
 
         friend ReportReader;
     };

--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -158,7 +158,7 @@ class SONATA_API ReportReader
                                const nonstd::optional<size_t>& tstride = nonstd::nullopt) const;
 
       private:
-        struct ElementIdsData {
+        struct NodeIdElementLayout {
             typename DataFrame<KeyType>::DataType ids;
             std::map<NodeID, Selection::Range> node_ranges;
             Selection::Range range;
@@ -175,7 +175,7 @@ class SONATA_API ReportReader
          * \param node_ids limit the report to the given selection. If nullptr, all nodes in the
          * report are used
          */
-        ElementIdsData getElementIds(
+        NodeIdElementLayout getNodeIdElementLayout(
             const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
 
         std::map<NodeID, Selection::Range> node_ranges_;

--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -98,13 +98,14 @@ class SONATA_API SpikeReader
     mutable std::map<std::string, Population> populations_;
 };
 
+  using Range = std::pair<uint64_t, uint64_t>;
+  using Ranges = std::vector<Range>;
+  using NodePointers = std::map<NodeID, Range>;
+
 template <typename KeyType>
 class SONATA_API ReportReader
 {
   public:
-    using Range = std::pair<uint64_t, uint64_t>;
-    using Ranges = std::vector<Range>;
-
     class Population
     {
       public:
@@ -147,8 +148,7 @@ class SONATA_API ReportReader
          * \param fn lambda applied to all ranges for all node ids
          */
         typename DataFrame<KeyType>::DataType getNodeIdElementIdMapping(
-            const nonstd::optional<Selection>& node_ids = nonstd::nullopt,
-            std::function<void(const Range&)> fn = nullptr) const;
+            const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
 
         /**
          * \param node_ids limit the report to the given selection.
@@ -167,7 +167,7 @@ class SONATA_API ReportReader
         std::pair<size_t, size_t> getIndex(const nonstd::optional<double>& tstart,
                                            const nonstd::optional<double>& tstop) const;
 
-        std::map<NodeID, Range> nodes_pointers_;
+        NodePointers nodes_pointers_;
         H5::Group pop_group_;
         std::vector<NodeID> nodes_ids_;
         double tstart_, tstop_, tstep_;
@@ -175,8 +175,10 @@ class SONATA_API ReportReader
         std::string time_units_;
         std::string data_units_;
         bool nodes_ids_sorted_ = false;
-        Selection::Values node_ids_from_selection(
+        std::pair<NodePointers, Range> node_pointers_from_selection(
             const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
+        typename DataFrame<KeyType>::DataType ids_from_node_pointers(
+            const std::pair<NodePointers, Range>& result) const;
 
         friend ReportReader;
     };

--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -160,8 +160,8 @@ class SONATA_API ReportReader
       private:
         struct NodeIdElementLayout {
             typename DataFrame<KeyType>::DataType ids;
-            std::map<NodeID, Selection::Range> node_ranges;
-            Selection::Range range;
+            Selection::Ranges node_ranges;
+            Selection::Range min_max_range;
         };
 
         Population(const H5::File& file, const std::string& populationName);

--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <map>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -99,10 +98,6 @@ class SONATA_API SpikeReader
     mutable std::map<std::string, Population> populations_;
 };
 
-using Range = std::pair<uint64_t, uint64_t>;
-using Ranges = std::vector<Range>;
-using NodePointers = std::map<NodeID, Range>;
-
 template <typename KeyType>
 class SONATA_API ReportReader
 {
@@ -163,21 +158,27 @@ class SONATA_API ReportReader
                                const nonstd::optional<size_t>& tstride = nonstd::nullopt) const;
 
       private:
+        struct ElementIdsData {
+            typename DataFrame<KeyType>::DataType ids;
+            std::map<NodeID, Selection::Range> node_pointers;
+            Selection::Range range;
+        };
+
         Population(const H5::File& file, const std::string& populationName);
         std::pair<size_t, size_t> getIndex(const nonstd::optional<double>& tstart,
                                            const nonstd::optional<double>& tstop) const;
         /**
-         * Return the ElementIds for the given selection, alongside the filtered NodePointers
+         * Return the element IDs for the given selection, alongside the filtered node pointers
          * and the range of positions where they fit in the file. This latter two are necessary
          * for performance to understand how and where to retrieve the data from storage.
          *
          * \param node_ids limit the report to the given selection. If nullptr, all nodes in the
          * report are used
          */
-        std::tuple<NodePointers, Range, typename DataFrame<KeyType>::DataType> getElementIds(
+        ElementIdsData getElementIds(
             const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
 
-        NodePointers nodes_pointers_;
+        std::map<NodeID, Selection::Range> node_pointers_;
         H5::Group pop_group_;
         std::vector<NodeID> nodes_ids_;
         double tstart_, tstop_, tstep_;

--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -160,7 +160,7 @@ class SONATA_API ReportReader
       private:
         struct ElementIdsData {
             typename DataFrame<KeyType>::DataType ids;
-            std::map<NodeID, Selection::Range> node_pointers;
+            std::map<NodeID, Selection::Range> node_ranges;
             Selection::Range range;
         };
 
@@ -178,7 +178,7 @@ class SONATA_API ReportReader
         ElementIdsData getElementIds(
             const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
 
-        std::map<NodeID, Selection::Range> node_pointers_;
+        std::map<NodeID, Selection::Range> node_ranges_;
         H5::Group pop_group_;
         std::vector<NodeID> nodes_ids_;
         double tstart_, tstop_, tstep_;

--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <map>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -145,7 +146,6 @@ class SONATA_API ReportReader
          *
          * \param node_ids limit the report to the given selection. If nullptr, all nodes in the
          * report are used
-         * \param fn lambda applied to all ranges for all node ids
          */
         typename DataFrame<KeyType>::DataType getNodeIdElementIdMapping(
             const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
@@ -166,10 +166,16 @@ class SONATA_API ReportReader
         Population(const H5::File& file, const std::string& populationName);
         std::pair<size_t, size_t> getIndex(const nonstd::optional<double>& tstart,
                                            const nonstd::optional<double>& tstop) const;
-        std::pair<NodePointers, Range> getNodePointers(
+        /**
+         * Return the ElementIds for the given selection, alongside the filtered NodePointers
+         * and the range of positions where they fit in the file. This latter two are necessary
+         * for performance to understand how and where to retrieve the data from storage.
+         *
+         * \param node_ids limit the report to the given selection. If nullptr, all nodes in the
+         * report are used
+         */
+        std::tuple<NodePointers, Range, typename DataFrame<KeyType>::DataType> getElementIds(
             const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
-        typename DataFrame<KeyType>::DataType getElementIds(const NodePointers& node_pointers,
-                                                            const Range& range) const;
 
         NodePointers nodes_pointers_;
         H5::Group pop_group_;

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -368,7 +368,7 @@ void bindReportReader(py::module& m, const std::string& prefix) {
             "get_node_id_element_id_mapping",
             [](const typename ReportType::Population& population,
                const nonstd::optional<Selection>& selection) {
-                return population.getNodeIdElementIdMapping(selection, nullptr);
+                return population.getNodeIdElementIdMapping(selection);
             },
             DOC_REPORTREADER_POP(getNodeIdElementIdMapping),
             "selection"_a = nonstd::nullopt)

--- a/src/report_reader.cpp
+++ b/src/report_reader.cpp
@@ -351,7 +351,11 @@ ReportReader<T>::Population::getNodeIdElementLayout(
             }
         }
 
-        // Reduces overhead of next IOps by clearing-up internal buffers of HDF5
+        // Temp. fix: When you ask for a large hyperslab in a dataset and then move
+        //            to another dataset in the same file where you also ask for
+        //            another large range, the next IOps take an extra few seconds.
+        //            We observed that fooling HDF5 hides the issue, but we should
+        //            verify this behaviour once new releases of HDF5 are available.
         dataset_elem_ids.select({min}, {1}).read(element_ids);
     }
 

--- a/src/report_reader.cpp
+++ b/src/report_reader.cpp
@@ -284,9 +284,10 @@ std::vector<NodeID> ReportReader<T>::Population::getNodeIds() const {
 }
 
 template <typename T>
-typename ReportReader<T>::Population::ElementIdsData ReportReader<T>::Population::getElementIds(
+typename ReportReader<T>::Population::NodeIdElementLayout
+ReportReader<T>::Population::getNodeIdElementLayout(
     const nonstd::optional<Selection>& node_ids) const {
-    ElementIdsData result;
+    NodeIdElementLayout result;
     result.range = {std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::min()};
     size_t element_ids_count = 0;
 
@@ -381,7 +382,7 @@ std::pair<size_t, size_t> ReportReader<T>::Population::getIndex(
 template <typename T>
 typename DataFrame<T>::DataType ReportReader<T>::Population::getNodeIdElementIdMapping(
     const nonstd::optional<Selection>& node_ids) const {
-    return getElementIds(node_ids).ids;
+    return getNodeIdElementLayout(node_ids).ids;
 }
 
 template <typename T>
@@ -407,12 +408,12 @@ DataFrame<T> ReportReader<T>::Population::get(const nonstd::optional<Selection>&
 
     // min and max offsets of the node_ids requested are calculated
     // to reduce the amount of IO that is brought to memory
-    const auto result = getElementIds(node_ids);
-    const auto& node_ranges = result.node_ranges;
-    const auto min = result.range.first;
-    const auto max = result.range.second;
+    const auto node_id_element_layout = getNodeIdElementLayout(node_ids);
+    const auto& node_ranges = node_id_element_layout.node_ranges;
+    const auto min = node_id_element_layout.range.first;
+    const auto max = node_id_element_layout.range.second;
 
-    data_frame.ids = result.ids;
+    data_frame.ids = node_id_element_layout.ids;
     if (data_frame.ids.empty()) {  // At the end no data available (wrong node_ids?)
         return DataFrame<T>{{}, {}, {}};
     }


### PR DESCRIPTION
The PR alters how the node IDs and positions are retrieved from storage. The node pointers are now filtered into a sub-map and used directly for different purposes, instead of splitting the IDs and positions like in the original code. The IO pattern for the IDs is also different and avoids the use of multiple hyperslabs, following a similar approach to what was introduced when fetching the actual data from storage (https://github.com/BlueBrain/libsonata/pull/104). In addition, the changes simplify and unify parts of the code (e.g., removing the use of lambda-functions).

Using a reference report of around 60TB, fetching one single timestamp from the file for all the GIDs would imply the following:
- In the former implementation, getting the metadata of each of the 4,234,929 GIDs of the report implies triggering a hyperslab + read for around 300 values per compartment (i.e., 4,234,929 reads of around 300 values each).
- In the proposed implementation, only a single hyperslab is triggered to fetch the data for the 4,234,929 IDs. Then, this data is conveniently filtered in memory.

These millions of small reads from the original implementation were causing problems recently in the GPFS file system of BB5, specially when scientists were launching multiple processes over multiple nodes conducting similar requests on big reports.