### PR TITLE
Improve mem. ops. + NodeID-ElementID mapping bindings

### DIFF
--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -362,7 +362,6 @@ void bindReportReader(py::module& m, const std::string& prefix) {
         .def("get_node_ids",
              &ReportType::Population::getNodeIds,
              "Return the list of nodes ids for this population")
-        // clang-format off
         .def("get_node_id_element_id_mapping",
              [](const typename ReportType::Population& population,
                 const nonstd::optional<Selection>& selection) {
@@ -370,7 +369,6 @@ void bindReportReader(py::module& m, const std::string& prefix) {
              },
              DOC_REPORTREADER_POP(getNodeIdElementIdMapping),
              "selection"_a = nonstd::nullopt)
-        // clang-format on
         .def_property_readonly("sorted",
                                &ReportType::Population::getSorted,
                                DOC_REPORTREADER_POP(getSorted))

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -333,7 +333,6 @@ void bindReportReader(py::module& m, const std::string& prefix) {
         // .ids, .data and .time members are owned by the c++ object. We can't do std::move.
         // To avoid copies, we must declare the owner of the data as the current Python
         // object. Numpy will adjust owner reference count according to returned arrays
-        // clang-format off
         .def_property_readonly("ids", [](const DataFrame<KeyType>& dframe) {
             std::array<ssize_t, 1> dims { ssize_t(dframe.ids.size()) };
             return managedMemoryArray(dframe.ids.data(), dims, dframe);
@@ -345,7 +344,6 @@ void bindReportReader(py::module& m, const std::string& prefix) {
             }
             return managedMemoryArray(dframe.data.data(), dims, dframe);
         })
-        // clang-format on
         .def_property_readonly("times", [](DataFrame<KeyType>& dframe) {
             return managedMemoryArray(dframe.times.data(), dframe.times.size(), dframe);
         });
@@ -364,14 +362,15 @@ void bindReportReader(py::module& m, const std::string& prefix) {
         .def("get_node_ids",
              &ReportType::Population::getNodeIds,
              "Return the list of nodes ids for this population")
-        .def(
-            "get_node_id_element_id_mapping",
-            [](const typename ReportType::Population& population,
-               const nonstd::optional<Selection>& selection) {
-                return population.getNodeIdElementIdMapping(selection);
-            },
-            DOC_REPORTREADER_POP(getNodeIdElementIdMapping),
-            "selection"_a = nonstd::nullopt)
+        // clang-format off
+        .def("get_node_id_element_id_mapping",
+             [](const typename ReportType::Population& population,
+                const nonstd::optional<Selection>& selection) {
+                 return asArray(population.getNodeIdElementIdMapping(selection));
+             },
+             DOC_REPORTREADER_POP(getNodeIdElementIdMapping),
+             "selection"_a = nonstd::nullopt)
+        // clang-format on
         .def_property_readonly("sorted",
                                &ReportType::Population::getSorted,
                                DOC_REPORTREADER_POP(getSorted))

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -334,8 +334,9 @@ class TestSomaReportPopulation(unittest.TestCase):
         np.testing.assert_allclose(sel_empty.data, np.empty(shape=(0, 0)))
 
     def test_get_node_id_element_id_mapping(self):
-        self.assertEqual(self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]]),
-                         [3, 4])
+        ids_mapping = self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]])
+        ids_mapping_ref = np.asarray([3, 4])
+        self.assertTrue((ids_mapping == ids_mapping_ref).all())
 
 
 class TestElementReportPopulation(unittest.TestCase):
@@ -390,8 +391,9 @@ class TestElementReportPopulation(unittest.TestCase):
                                    [81.0, 81.1, 81.2, 81.3, 81.4, 81.5, 81.6, 81.7, 81.8, 81.9], 1e-6, 0)
 
     def test_get_node_id_element_id_mapping(self):
-        self.assertEqual(self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]]),
-                         [[3, 5], [3, 5], [3, 6], [3, 6], [3, 7], [4, 7], [4, 8], [4, 8], [4, 9], [4, 9]])
+        ids_mapping = self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]])
+        ids_mapping_ref = np.asarray([[3, 5], [3, 5], [3, 6], [3, 6], [3, 7], [4, 7], [4, 8], [4, 8], [4, 9], [4, 9]])
+        self.assertTrue((ids_mapping == ids_mapping_ref).all())
 
 
 class TestNodePopulationFailure(unittest.TestCase):

--- a/src/report_reader.cpp
+++ b/src/report_reader.cpp
@@ -421,7 +421,7 @@ DataFrame<T> ReportReader<T>::Population::get(const nonstd::optional<Selection>&
 
     // min and max offsets of the node_ids requested are calculated
     // to reduce the amount of IO that is brought to memory
-    const auto node_id_element_layout = getNodeIdElementLayout(node_ids);
+    auto node_id_element_layout = getNodeIdElementLayout(node_ids);
     const auto& node_ranges = node_id_element_layout.node_ranges;
     const auto min = node_id_element_layout.min_max_range.first;
     const auto max = node_id_element_layout.min_max_range.second;
@@ -433,11 +433,11 @@ DataFrame<T> ReportReader<T>::Population::get(const nonstd::optional<Selection>&
     // Fill times
     DataFrame<T> data_frame;
     for (size_t i = index_start; i <= index_stop; i += stride) {
-        data_frame.times.push_back(times_index_[i].second);
+        data_frame.times.emplace_back(times_index_[i].second);
     }
 
     // Fill ids
-    data_frame.ids = node_id_element_layout.ids;
+    data_frame.ids.swap(node_id_element_layout.ids);
 
     // Fill .data member
     size_t n_time_entries = ((index_stop - index_start) / stride) + 1;


### PR DESCRIPTION
The PR improves the copy of the returned `ids` when fetching the data from the reports, as well as the Python bindings related to the NodeID-ElementID mapping (https://github.com/BlueBrain/libsonata/pull/168):

- In the former case, the `std::vector` is [swapped in a constant-time operation instead of a full copy](https://www.cplusplus.com/reference/vector/vector/swap). This is particularly useful when a large number of GIDs is requested. 
- In the latter case, the binding of the NodeID-ElementID mapping from is improved, returning a `numpy.array` instead of a list of tuples. Hence, providing directly the result generated from the C++ code without any additional copies.

Using the same ~60TB report from https://github.com/BlueBrain/libsonata/pull/174 that contains 4.2M GIDs (1.5B compartments), the following table illustrates the performance obtained by fetching a single timestep and varying the number of GIDs requested:

```
 # GIDS |            v0.1.11 |                 PR
 ------- -------------------- -------------------
      1 |  0.010879278182983 |  0.001698255538940
     10 |  5.343438386917114 |  5.512796163558960
    100 |  5.943392753601074 |  5.604890823364258
   1000 |  6.406604766845703 |  6.062043905258179
  10000 |  6.451685428619385 |  6.049137830734253
 100000 |  7.101217269897461 |  6.462664365768433
1000000 | 12.762017250061035 |  9.955524444580078
4234929 | 27.868659019470215 | 18.158316850662230
```

On the other hand, when using in Python the function `get_node_id_element_id_mapping()` from https://github.com/BlueBrain/libsonata/pull/168, the following table shows the performance obtained varying the number of GIDs requested:

```
 # GIDS |            v0.1.11 |                 PR
 ------- -------------------- -------------------
      1 |    0.0158734321594 |  0.001111268997192
     10 |    2.6325545310974 |  2.509858608245849
    100 |    2.9563860893249 |  2.782548427581787
   1000 |    3.2792141437530 |  2.988783836364746
  10000 |    5.4664847850799 |  3.832525491714477
 100000 |   24.0672097206115 |  3.506523370742798
1000000 |  225.1766004562378 |  6.213826656341553
4234929 | 1017.6884262561798 | 11.914409875869751
```

Note that there has been other attempts to improve the copies of the voltages and even the tuples for the NodeID-ElementID mapping container, but the benefits turned out to be negligible compared to the source code complexity that was required.

