### PR TITLE
Add support for IO-blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 .cache
 .clangd
 build
+spack-build*
 .eggs/
 .tox/
 libsonata.cpython-*.so
 python/__pycache__/
+python/libsonata.egg-info/
 *.pyc
 venv/
 cpp/

--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -160,7 +160,9 @@ class SONATA_API ReportReader
         struct NodeIdElementLayout {
             typename DataFrame<KeyType>::DataType ids;
             Selection::Ranges node_ranges;
-            Selection::Range min_max_range;
+            std::vector<uint64_t> node_offsets;
+            std::vector<uint64_t> node_index;
+            Selection::Ranges min_max_blocks;
         };
 
         Population(const H5::File& file, const std::string& populationName);
@@ -177,14 +179,16 @@ class SONATA_API ReportReader
         NodeIdElementLayout getNodeIdElementLayout(
             const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
 
-        std::map<NodeID, Selection::Range> node_ranges_;
         H5::Group pop_group_;
-        std::vector<NodeID> nodes_ids_;
+        std::vector<NodeID> node_ids_;
+        std::vector<Selection::Range> node_ranges_;
+        std::vector<uint64_t> node_offsets_;
+        std::vector<uint64_t> node_index_;
         double tstart_, tstop_, tstep_;
         std::vector<std::pair<size_t, double>> times_index_;
         std::string time_units_;
         std::string data_units_;
-        bool nodes_ids_sorted_ = false;
+        bool is_node_ids_sorted_ = false;
 
         friend ReportReader;
     };

--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -28,16 +28,6 @@ struct SONATA_API DataFrame {
 using Spike = std::pair<NodeID, double>;
 using Spikes = std::vector<Spike>;
 
-/**
-  const SpikeReader file(filename);
-  auto pops = file.getPopulationNames();
-  for (const auto& data: file[pops.openPopulation(0).get(Selection{12UL, 34UL, 58UL})) {
-      NodeID node_id;
-      double timestamp;
-      std::tie(node_id, timestamp) = data;
-      std::cout << "[" << timestamp << "] " << node_id << std::endl;
-  }
-*/
 class SONATA_API SpikeReader
 {
   public:
@@ -188,7 +178,7 @@ class SONATA_API ReportReader
         std::vector<std::pair<size_t, double>> times_index_;
         std::string time_units_;
         std::string data_units_;
-        bool is_node_ids_sorted_ = false;
+        bool is_node_ids_sorted_;
 
         friend ReportReader;
     };

--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -125,14 +125,16 @@ class SONATA_API ReportReader
          * - For Soma report reader, the return value will be the Node ID to which the report
          *   value belongs to.
          * - For Element/full compartment readers, the return value will be an array with 2
-         *   elements, the first element is the Node ID and the second element is the 
+         *   elements, the first element is the Node ID and the second element is the
          *   compartment ID of the given Node.
          *
          * \param node_ids limit the report to the given selection. If nullptr, all nodes in the
          * report are used
+         * \param block_gap_limit gap limit between each IO block while fetching data from storage
          */
         typename DataFrame<KeyType>::DataType getNodeIdElementIdMapping(
-            const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
+            const nonstd::optional<Selection>& node_ids = nonstd::nullopt,
+            const nonstd::optional<size_t>& block_gap_limit = nonstd::nullopt) const;
 
         /**
          * \param node_ids limit the report to the given selection.
@@ -140,11 +142,14 @@ class SONATA_API ReportReader
          * indicates no limit. \param tstop return voltages occurring on or before tstop.
          * tstop=nonstd::nullopt indicates no limit. \param tstride indicates every how many
          * timesteps we read data. tstride=nonstd::nullopt indicates that all timesteps are read.
+         * \param block_gap_limit gap limit between each IO block while fetching data from storage.
          */
-        DataFrame<KeyType> get(const nonstd::optional<Selection>& node_ids = nonstd::nullopt,
-                               const nonstd::optional<double>& tstart = nonstd::nullopt,
-                               const nonstd::optional<double>& tstop = nonstd::nullopt,
-                               const nonstd::optional<size_t>& tstride = nonstd::nullopt) const;
+        DataFrame<KeyType> get(
+            const nonstd::optional<Selection>& node_ids = nonstd::nullopt,
+            const nonstd::optional<double>& tstart = nonstd::nullopt,
+            const nonstd::optional<double>& tstop = nonstd::nullopt,
+            const nonstd::optional<size_t>& tstride = nonstd::nullopt,
+            const nonstd::optional<size_t>& block_gap_limit = nonstd::nullopt) const;
 
       private:
         struct NodeIdElementLayout {
@@ -165,9 +170,11 @@ class SONATA_API ReportReader
          *
          * \param node_ids limit the report to the given selection. If nullptr, all nodes in the
          * report are used
+         * \param block_gap_limit gap limit between each IO block while fetching data from storage
          */
         NodeIdElementLayout getNodeIdElementLayout(
-            const nonstd::optional<Selection>& node_ids = nonstd::nullopt) const;
+            const nonstd::optional<Selection>& node_ids = nonstd::nullopt,
+            const nonstd::optional<size_t>& block_gap_limit = nonstd::nullopt) const;
 
         H5::Group pop_group_;
         std::vector<NodeID> node_ids_;

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -358,18 +358,21 @@ void bindReportReader(py::module& m, const std::string& prefix) {
              "node_ids"_a = nonstd::nullopt,
              "tstart"_a = nonstd::nullopt,
              "tstop"_a = nonstd::nullopt,
-             "tstride"_a = nonstd::nullopt)
+             "tstride"_a = nonstd::nullopt,
+             "block_gap_limit"_a = nonstd::nullopt)
         .def("get_node_ids",
              &ReportType::Population::getNodeIds,
              "Return the list of nodes ids for this population")
         .def(
             "get_node_id_element_id_mapping",
             [](const typename ReportType::Population& population,
-               const nonstd::optional<Selection>& selection) {
-                return asArray(population.getNodeIdElementIdMapping(selection));
+               const nonstd::optional<Selection>& selection,
+               const nonstd::optional<size_t>& block_gap_limit) {
+                return asArray(population.getNodeIdElementIdMapping(selection, block_gap_limit));
             },
             DOC_REPORTREADER_POP(getNodeIdElementIdMapping),
-            "selection"_a = nonstd::nullopt)
+            "selection"_a = nonstd::nullopt,
+            "block_gap_limit"_a = nonstd::nullopt)
         .def_property_readonly("sorted",
                                &ReportType::Population::getSorted,
                                DOC_REPORTREADER_POP(getSorted))

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -339,12 +339,12 @@ class TestSomaReportPopulation(unittest.TestCase):
         self.assertTrue((ids_mapping == ids_mapping_ref).all())
 
     def test_block_gap_limit(self):
-        ids_mapping = self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=2097152) # >= 1 x GPFS block
+        ids_mapping = self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=4194304) # >= 1 x GPFS block
         ids_mapping_ref = np.asarray([3, 4])
         self.assertTrue((ids_mapping == ids_mapping_ref).all())
 
         with self.assertRaises(SonataError):
-            self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=2097151) # < 1 x GPFS block
+            self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=4194303) # < 1 x GPFS block
 
 
 class TestElementReportPopulation(unittest.TestCase):
@@ -404,12 +404,12 @@ class TestElementReportPopulation(unittest.TestCase):
         self.assertTrue((ids_mapping == ids_mapping_ref).all())
 
     def test_block_gap_limit(self):
-        ids_mapping = self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=2097152) # >= 1 x GPFS block
+        ids_mapping = self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=4194304) # >= 1 x GPFS block
         ids_mapping_ref = np.asarray([[3, 5], [3, 5], [3, 6], [3, 6], [3, 7], [4, 7], [4, 8], [4, 8], [4, 9], [4, 9]])
         self.assertTrue((ids_mapping == ids_mapping_ref).all())
 
         with self.assertRaises(SonataError):
-            self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=2097151) # < 1 x GPFS block
+            self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=4194303) # < 1 x GPFS block
 
 
 class TestNodePopulationFailure(unittest.TestCase):

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -330,6 +330,14 @@ class TestSomaReportPopulation(unittest.TestCase):
         keys_all_ref = np.asarray([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertTrue((keys_all == keys_all_ref).all())
 
+        data_begin = sel_all.data[0][:10]
+        data_begin_ref = np.asarray([10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0], dtype=np.float32)
+        self.assertTrue((data_begin == data_begin_ref).all())
+
+        data_end = sel_all.data[-1][-10:]
+        data_end_ref = np.asarray([20.9, 1.9, 2.9, 3.9, 4.9, 5.9, 6.9, 7.9, 8.9, 9.9], dtype=np.float32)
+        self.assertTrue((data_end == data_end_ref).all())
+
         sel_empty = self.test_obj['All'].get(node_ids=[])
         np.testing.assert_allclose(sel_empty.data, np.empty(shape=(0, 0)))
 

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -339,6 +339,14 @@ class TestSomaReportPopulation(unittest.TestCase):
         ids_mapping_ref = np.asarray([3, 4])
         self.assertTrue((ids_mapping == ids_mapping_ref).all())
 
+    def test_block_gap_limit(self):
+        ids_mapping = self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=2097152) # >= 1 x GPFS block
+        ids_mapping_ref = np.asarray([3, 4])
+        self.assertTrue((ids_mapping == ids_mapping_ref).all())
+
+        with self.assertRaises(SonataError):
+            self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=2097151) # < 1 x GPFS block
+
 
 class TestElementReportPopulation(unittest.TestCase):
     def setUp(self):
@@ -395,6 +403,14 @@ class TestElementReportPopulation(unittest.TestCase):
         ids_mapping = self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]])
         ids_mapping_ref = np.asarray([[3, 5], [3, 5], [3, 6], [3, 6], [3, 7], [4, 7], [4, 8], [4, 8], [4, 9], [4, 9]])
         self.assertTrue((ids_mapping == ids_mapping_ref).all())
+
+    def test_block_gap_limit(self):
+        ids_mapping = self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=2097152) # >= 1 x GPFS block
+        ids_mapping_ref = np.asarray([[3, 5], [3, 5], [3, 6], [3, 6], [3, 7], [4, 7], [4, 8], [4, 8], [4, 9], [4, 9]])
+        self.assertTrue((ids_mapping == ids_mapping_ref).all())
+
+        with self.assertRaises(SonataError):
+            self.test_obj['All'].get_node_id_element_id_mapping([[3, 5]], block_gap_limit=2097151) # < 1 x GPFS block
 
 
 class TestNodePopulationFailure(unittest.TestCase):

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -325,7 +325,8 @@ class TestSomaReportPopulation(unittest.TestCase):
         self.assertTrue((keys == keys_ref).all())
         np.testing.assert_allclose(sel.data, [[13.8, 14.8], [13.9, 14.9]])
 
-        sel_all = self.test_obj['All'].get()
+        node_ids_ordered = sorted(self.test_obj['All'].get_node_ids())
+        sel_all = self.test_obj['All'].get(node_ids = node_ids_ordered)
         keys_all = sel_all.ids
         keys_all_ref = np.asarray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
         self.assertTrue((keys_all == keys_all_ref).all())

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -325,10 +325,9 @@ class TestSomaReportPopulation(unittest.TestCase):
         self.assertTrue((keys == keys_ref).all())
         np.testing.assert_allclose(sel.data, [[13.8, 14.8], [13.9, 14.9]])
 
-        node_ids_ordered = sorted(self.test_obj['All'].get_node_ids())
-        sel_all = self.test_obj['All'].get(node_ids = node_ids_ordered)
+        sel_all = self.test_obj['All'].get()
         keys_all = sel_all.ids
-        keys_all_ref = np.asarray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+        keys_all_ref = np.asarray([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertTrue((keys_all == keys_all_ref).all())
 
         sel_empty = self.test_obj['All'].get(node_ids=[])

--- a/src/report_reader.cpp
+++ b/src/report_reader.cpp
@@ -231,9 +231,14 @@ ReportReader<T>::Population::Population(const H5::File& file, const std::string&
     const auto mapping_group = pop_group_.getGroup("mapping");
     mapping_group.getDataSet("node_ids").read(node_ids_);
 
-    // Expand the pointers into tuples that define the range of each GID
     std::vector<uint64_t> index_pointers;
     mapping_group.getDataSet("index_pointers").read(index_pointers);
+
+    if (index_pointers.size() != (node_ids_.size() + 1)) {
+        throw SonataError("'index_pointers' dataset size must be 'node_ids' size plus one");
+    }
+
+    // Expand the pointers into tuples that define the range of each GID
     size_t element_ids_count = 0;
     for (size_t i = 0; i < node_ids_.size(); ++i) {
         node_ranges_.emplace_back(index_pointers[i], index_pointers[i + 1]);  // Range of GID

--- a/src/report_reader.cpp
+++ b/src/report_reader.cpp
@@ -315,11 +315,11 @@ ReportReader<T>::Population::getNodeIdElementLayout(
     std::vector<NodeID> concrete_node_ids;
     size_t element_ids_count = 0;
 
-    // Set the gap between IO blocks while fetching data (Default: 128MB / 8 x GPFS blocks)
+    // Set the gap between IO blocks while fetching data (Default: 64MB / 4 x GPFS blocks)
     const size_t block_gap_limit = _block_gap_limit.value_or(16777216);
 
-    if (block_gap_limit < 2097152) {
-        throw SonataError("block_gap_limit must be at least 2097152 (16MB / 1 x GPFS block)");
+    if (block_gap_limit < 4194304) {
+        throw SonataError("block_gap_limit must be at least 4194304 (16MB / 1 x GPFS block)");
     }
 
     // Take all nodes if no selection is provided

--- a/src/report_reader.cpp
+++ b/src/report_reader.cpp
@@ -81,16 +81,11 @@ void filterTimestampSorted(Spikes& spikes, double tstart, double tstop) {
     spikes.erase(spikes.begin(), begin);
 }
 
-template <typename T>
-void emplace_ids(T& key, NodeID node_id, ElementID element_id);
-
-template <>
-void emplace_ids(NodeID& key, NodeID node_id, ElementID /* element_id */) {
+inline void emplace_ids(NodeID& key, NodeID node_id, ElementID /* element_id */) {
     key = node_id;
 }
 
-template <>
-void emplace_ids(CompartmentID& key, NodeID node_id, ElementID element_id) {
+inline void emplace_ids(CompartmentID& key, NodeID node_id, ElementID element_id) {
     key[0] = node_id;
     key[1] = element_id;
 }
@@ -402,7 +397,7 @@ ReportReader<T>::Population::getNodeIdElementLayout(
 
                 auto offset = result.node_offsets[index];
                 for (auto i = range.first; i < range.second; i++, offset++) {
-                    emplace_ids<T>(result.ids[offset], node_id, element_ids[i]);
+                    emplace_ids(result.ids[offset], node_id, element_ids[i]);
                 }
             }
         }

--- a/tests/test_report_reader.cpp
+++ b/tests/test_report_reader.cpp
@@ -92,9 +92,9 @@ TEST_CASE("SomaReportReader", "[base]") {
     REQUIRE(data_all.ids == DataFrame<NodeID>::DataType{{10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                                          20, 1,  2,  3,  4,  5,  6,  7,  8,  9}});
     REQUIRE(std::vector<float>(data_all.data.begin(), data_all.data.begin() + 10)  == 
-            std::vector<float>{11.9f, 12.9f, 13.9f, 14.9f, 15.9f, 16.9f, 17.9f, 18.9f, 19.9f, 20.9f});
+            std::vector<float>{10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 16.0f, 17.0f, 18.0f, 19.0f});
     REQUIRE(std::vector<float>(data_all.data.end() - 10, data_all.data.end()) == 
-            std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f,});
+            std::vector<float>{20.9f, 1.9f, 2.9f, 3.9f, 4.9f, 5.9f, 6.9f, 7.9f, 8.9f, 9.9f});
 
     auto data_empty = pop.get(Selection({}));
     REQUIRE(data_empty.data == std::vector<float>{});

--- a/tests/test_report_reader.cpp
+++ b/tests/test_report_reader.cpp
@@ -89,12 +89,12 @@ TEST_CASE("SomaReportReader", "[base]") {
     REQUIRE(data.data == std::vector<float>{3.2f, 4.2f, 3.3f, 4.3f, 3.4f, 4.4f, 3.5f, 4.5f});
 
     auto data_all = pop.get();
-    REQUIRE(data_all.ids == DataFrame<NodeID>::DataType{{1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
-                                                         11, 12, 13, 14, 15, 16, 17, 18, 19, 20}});
+    REQUIRE(data_all.ids == DataFrame<NodeID>::DataType{{10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                                         20, 1,  2,  3,  4,  5,  6,  7,  8,  9}});
     REQUIRE(std::vector<float>(data_all.data.begin(), data_all.data.begin() + 10)  == 
-            std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f,});
-    REQUIRE(std::vector<float>(data_all.data.end() - 10, data_all.data.end()) == 
             std::vector<float>{11.9f, 12.9f, 13.9f, 14.9f, 15.9f, 16.9f, 17.9f, 18.9f, 19.9f, 20.9f});
+    REQUIRE(std::vector<float>(data_all.data.end() - 10, data_all.data.end()) == 
+            std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f,});
 
     auto data_empty = pop.get(Selection({}));
     REQUIRE(data_empty.data == std::vector<float>{});

--- a/tests/test_report_reader.cpp
+++ b/tests/test_report_reader.cpp
@@ -102,10 +102,10 @@ TEST_CASE("SomaReportReader", "[base]") {
     auto ids = pop.getNodeIdElementIdMapping(Selection({{3, 5}}));
     REQUIRE(ids == std::vector<NodeID>{3, 4});
 
-    ids = pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 2097152); // >= 1 x GPFS block
+    ids = pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 4194304); // >= 1 x GPFS block
     REQUIRE(ids == std::vector<NodeID>{3, 4});
 
-    REQUIRE_THROWS(pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 2097151)); // < 1 x GPFS block
+    REQUIRE_THROWS(pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 4194303)); // < 1 x GPFS block
 }
 
 TEST_CASE("ElementReportReader limits", "[base]") {
@@ -172,8 +172,8 @@ TEST_CASE("ElementReportReader", "[base]") {
     auto ids = pop.getNodeIdElementIdMapping(Selection({{3, 5}}));
     REQUIRE(ids == std::vector<CompartmentID>{{3, 5}, {3, 5}, {3, 6}, {3, 6}, {3, 7}, {4, 7}, {4, 8}, {4, 8}, {4, 9}, {4, 9}});
 
-    ids = pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 2097152); // >= 1 x GPFS block
+    ids = pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 4194304); // >= 1 x GPFS block
     REQUIRE(ids == std::vector<CompartmentID>{{3, 5}, {3, 5}, {3, 6}, {3, 6}, {3, 7}, {4, 7}, {4, 8}, {4, 8}, {4, 9}, {4, 9}});
 
-    REQUIRE_THROWS(pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 2097151)); // < 1 x GPFS block
+    REQUIRE_THROWS(pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 4194303)); // < 1 x GPFS block
 }

--- a/tests/test_report_reader.cpp
+++ b/tests/test_report_reader.cpp
@@ -101,6 +101,11 @@ TEST_CASE("SomaReportReader", "[base]") {
 
     auto ids = pop.getNodeIdElementIdMapping(Selection({{3, 5}}));
     REQUIRE(ids == std::vector<NodeID>{3, 4});
+
+    ids = pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 2097152); // >= 1 x GPFS block
+    REQUIRE(ids == std::vector<NodeID>{3, 4});
+
+    REQUIRE_THROWS(pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 2097151)); // < 1 x GPFS block
 }
 
 TEST_CASE("ElementReportReader limits", "[base]") {
@@ -166,4 +171,9 @@ TEST_CASE("ElementReportReader", "[base]") {
 
     auto ids = pop.getNodeIdElementIdMapping(Selection({{3, 5}}));
     REQUIRE(ids == std::vector<CompartmentID>{{3, 5}, {3, 5}, {3, 6}, {3, 6}, {3, 7}, {4, 7}, {4, 8}, {4, 8}, {4, 9}, {4, 9}});
+
+    ids = pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 2097152); // >= 1 x GPFS block
+    REQUIRE(ids == std::vector<CompartmentID>{{3, 5}, {3, 5}, {3, 6}, {3, 6}, {3, 7}, {4, 7}, {4, 8}, {4, 8}, {4, 9}, {4, 9}});
+
+    REQUIRE_THROWS(pop.getNodeIdElementIdMapping(Selection({{3, 5}}), 2097151)); // < 1 x GPFS block
 }


### PR DESCRIPTION
The improvements provided in #174 and available in `libsonata v0.1.11`, introduced a specific limitation while fetching a small number of widely-disperse GIDs in very large reports. The `{min,max}` optimization, inspired by [ROMIO's Data Sieving](https://web.cels.anl.gov/~thakur/papers/romio-coll.pdf), would in such case force the implementation to retrieve large amounts of data without considering the gap between each of the position ranges of the GIDs. This means that, if we fetch only 2 GIDs that coincidentally are located in the very first entry of the dataset and in the very last one, the library would then read the complete report file just to filter in memory the two selected values.

To overcome these constraints while still trying to reduce the number of IO requests requested to the parallel file system, the current PR introduces several changes and optimizations:

- The `{min,max}` range is now replaced by a collection of ranges or IO blocks, in which each range contains a subset of GIDs. The gap between each IO block is fixed at 64MB (or 4 blocks in GPFS), allowing the code to adapt depending on the number of GIDs requested and their distribution in the file. For instance, a higher number of GIDs would generally imply a lower number of IO blocks, and vice versa.
- A flat-map inspired implementation replaces the existing `std::map` that is utilized to index the GIDs and their positions. The idea is to reduce the overhead when opening populations from very large report files with millions of GIDs. Moreover, it allows us to re-index the content based on different keys, without moving the actual data. For this purpose, the implementation uses several `std::vector` and a dedicated index that refers to the values contained in these vectors. When creating the IO blocks, it is enough to re-index the content by the position ranges and to create the groups based on this new index.
- Other minor changes are included, such as behaviour consistency between asking for all the GIDs or a subset of the GIDs, clarification comments, and others.

Using the same ~60TB report utilized in #174 and #179, the following table illustrates the performance difference between `v0.1.11` and the proposed PR by fetching a single timestep while varying the number of GIDs requested. The `Open` column reflects the cost of opening the population as part of the elapsed execution time, while the `Select` column shows the cost of the operations related to the selection of the GIDs in Python, and the `Get` column illustrates the cost of the actual retrieval of the data. The total cost is reflected in `Elapsed`. All measurements are provided in seconds:

```
v0.1.11
-------------------------------------------------------
   GIDs |   Elapsed |      Open |    Select |       Get
      1 |  5.347993 |  4.720139 |  0.626175 |  0.001667
     10 | 11.422943 |  5.391727 |  0.781538 |  5.249666
    100 | 11.814635 |  5.087994 |  0.763447 |  5.963183
   1000 | 12.090420 |  5.105253 |  0.774254 |  6.210903
  10000 | 12.084519 |  5.047278 |  0.779182 |  6.258047
 100000 | 12.789811 |  5.165905 |  0.785131 |  6.838766
1000000 | 18.066422 |  5.148455 |  0.834916 | 12.083038
4234929 | 33.317796 |  5.097557 |  0.414970 | 27.805258

PR
-------------------------------------------------------
   GIDs |   Elapsed |      Open |    Select |       Get
      1 |  1.558976 |  0.933911 |  0.623337 |  0.001715
     10 |  1.450080 |  0.733224 |  0.628178 |  0.088669
    100 |  4.454307 |  0.749991 |  0.638895 |  3.065413
   1000 |  7.777399 |  0.803403 |  0.632553 |  6.341434
  10000 |  7.836496 |  0.821947 |  0.635333 |  6.379207
 100000 |  8.150157 |  0.815197 |  0.636635 |  6.698314
1000000 | 12.450882 |  0.806348 |  0.706298 | 10.938223
4234929 | 21.047557 |  0.780823 |  0.272458 | 19.994266
```

From the results, it can be observed that the use of multiple-blocks and the integration of a flat-map reduces the overhead of the execution time considerably, specially in small number of GIDs. After 100 GIDs, the implementation can only find a single IO block to fetch from storage and, thus, its behaviour is equivalent to the original `{min,max}` single-block implementation of `v0.1.11`. Hence, allowing us to be more flexible in lower number of GIDs, and more aggressive in large number of GIDs to prevent overheads in the parallel file system. This is clearly noticeable by observing the `Get` column of the table above (note that the performance is improved because the PR also contains the changes in #179).

The following table reflects the number of blocks created by the implementation for each of the tests, showing how we can now be more flexible in requests with lower number of GIDs and more aggressive in requests with large number of GIDs:

```
PR
-----------------
   GIDs |  Blocks
      1 |       1
      2 |       2
     10 |      10
    100 |      32
   1000 |       1
  10000 |       1
 100000 |       1
1000000 |       1
4234929 |       1
```

If we now evaluate the edge case mentioned in the beginning of this description, the entry with 2 GIDs in the following table illustrates the performance by fetching the very first and the very last GID of the same ~60TB report for a single timestep:

```
v0.1.11
-------------------------------------------------------
   GIDs |   Elapsed |      Open |    Select |       Get
      2 | 11.180127 |  4.742555 |  0.205418 |  6.232141

PR
-------------------------------------------------------
   GIDs |   Elapsed |      Open |    Select |       Get
      2 |  1.103376 |  0.893741 |  0.209070 |  0.000555
```