### PR TITLE
Add a check when feeding a directory path to readFile

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -14,7 +14,6 @@
 #include <fstream>
 
 std::string readFile(const std::string& path) {
-
     namespace fs = ghc::filesystem;
 
     if (!fs::is_regular_file(path))

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -9,10 +9,17 @@
 
 #include "utils.h"
 
+#include "../extlib/filesystem.hpp"
+
 #include <fstream>
 
-
 std::string readFile(const std::string& path) {
+
+    namespace fs = ghc::filesystem;
+
+    if (!fs::is_regular_file(path))
+        throw std::runtime_error("Path `" + path + "` is not a file");
+
     std::ifstream file(path);
 
     if (file.fail())


### PR DESCRIPTION
While trying to read a SONATA config file, by mistake I generated a path that pointed to the folder contained the config file, rather than the file itself.

`file.fail()` evaluated to false, so it tried to read the directory.

`file.tellg()` returned 0, so it tried to allocate 0 bytes for the std::string which resulted on a segfault