### PR TITLE
for `biophysical` node populations, don't raise error if alternate_morphologies exists

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -637,10 +637,12 @@ class CircuitConfig::PopulationResolver
                 }
 
                 if (it->second.type == "biophysical") {
-                    if (it->second.morphologiesDir.empty()) {
+                    if (it->second.morphologiesDir.empty() &&
+                        it->second.alternateMorphologyFormats.empty()) {
                         throw SonataError(
                             fmt::format("Node population '{}' is defined as 'biophysical' "
-                                        "but does not define 'morphology_dir'",
+                                        "but does not define 'morphologies_dir' or "
+                                        "'alternateMorphologyFormats'",
                                         population));
                     } else if (it->second.biophysicalNeuronModelsDir.empty()) {
                         throw SonataError(


### PR DESCRIPTION
* fix python tests; unittest requires everything be declared in a class;
  can't have bare function
* hat-tip to @joni-herttuainen for noticing we weren't throwing an error
  when we should