### PR TITLE
SimulationConfig report "cells" field should be optional

### DIFF
--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -692,7 +692,7 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.list_report_names,
                          { "axonal_comp_centers", "cell_imembrane", "compartment", "soma" })
 
-        self.assertEqual(self.config.report('soma').cells, 'Mosaic')
+        self.assertEqual(self.config.report('soma').cells, 'Column')
         self.assertEqual(self.config.report('soma').type, Report.Type.compartment)
         self.assertEqual(self.config.report('soma').compartments, Report.Compartments.center)
         self.assertEqual(self.config.report('soma').enabled, True)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -847,7 +847,7 @@ class SimulationConfig::Parser
             const auto& valueIt = it.value();
             const std::string debugStr = "report " + it.key();
 
-            parseOptional(valueIt, "cells", report.cells, {parseNodeSet()});
+            parseOptional(valueIt, "cells", report.cells, parseNodeSet());
             parseOptional(valueIt, "sections", report.sections, {Report::Sections::soma});
             parseMandatory(valueIt, "type", debugStr, report.type);
             parseOptional(valueIt, "scaling", report.scaling, {Report::Scaling::area});

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -847,7 +847,7 @@ class SimulationConfig::Parser
             const auto& valueIt = it.value();
             const std::string debugStr = "report " + it.key();
 
-            parseMandatory(valueIt, "cells", debugStr, report.cells);
+            parseOptional(valueIt, "cells", report.cells, {parseNodeSet()});
             parseOptional(valueIt, "sections", report.sections, {Report::Sections::soma});
             parseMandatory(valueIt, "type", debugStr, report.type);
             parseOptional(valueIt, "scaling", report.scaling, {Report::Scaling::area});

--- a/tests/data/config/simulation_config.json
+++ b/tests/data/config/simulation_config.json
@@ -212,7 +212,6 @@
     },
     "reports": {
          "soma": {
-              "cells": "Mosaic",
               "sections": "soma",
               "type": "compartment",
               "variable_name": "v",

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -333,7 +333,7 @@ TEST_CASE("SimulationConfig") {
               "soma"
               });
 
-        CHECK(config.getReport("soma").cells == "Mosaic");
+        CHECK(config.getReport("soma").cells == "Column");
         CHECK(config.getReport("soma").type == SimulationConfig::Report::Type::compartment);
         CHECK(config.getReport("soma").compartments == SimulationConfig::Report::Compartments::center);
         CHECK(config.getReport("soma").enabled == true);


### PR DESCRIPTION
Consistency with the documentation
https://bbpgitlab.epfl.ch/common/doc/circuit-documentation/-/blob/main/source/sonata_simulation.rst