### PR TITLE
Teach SimulationConfig to return getExpandedJSON like CircuitConfig

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -611,11 +611,17 @@ class SONATA_API SimulationConfig
      */
     const nonstd::optional<std::string>& getNodeSet() const noexcept;
 
+    /**
+     * Returns the configuration file JSON whose variables have been expanded by the
+     * manifest entries.
+     */
+    const std::string& getExpandedJSON() const;
+
   private:
     // JSON string
-    const std::string _jsonContent;
+    std::string _expandedJSON;
     // Base path of the simulation config file
-    const std::string _basePath;
+    std::string _basePath;
 
     // Run section
     Run _run;

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -918,7 +918,7 @@ PYBIND11_MODULE(_libsonata, m) {
         .def_static("from_file",
                     [](py::object path) { return SimulationConfig::fromFile(py::str(path)); })
         .def_property_readonly("base_path", &SimulationConfig::getBasePath)
-        .def_property_readonly("json", &SimulationConfig::getJSON)
+        .def_property_readonly("expanded_json", &SimulationConfig::getExpandedJSON)
         .def_property_readonly("run", &SimulationConfig::getRun)
         .def_property_readonly("output", &SimulationConfig::getOutput)
         .def_property_readonly("conditions", &SimulationConfig::getConditions)

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -691,7 +691,7 @@ class TestCircuitConfig(unittest.TestCase):
 class TestSimulationConfig(unittest.TestCase):
     def setUp(self):
         self.config = SimulationConfig.from_file(
-                        os.path.join(PATH, 'config/simulation_config.json'))
+                        os.path.join(PATH, 'config', 'simulation_config.json'))
 
     def test_basic(self):
         self.assertEqual(self.config.base_path, os.path.abspath(os.path.join(PATH, 'config')))
@@ -705,7 +705,7 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.run.forward_skip, 500)
 
         self.assertEqual(self.config.output.output_dir,
-                         os.path.abspath(os.path.join(PATH, 'config/output')))
+                         os.path.abspath(os.path.join(PATH, 'config/some/path/output')))
         self.assertEqual(self.config.output.spikes_file, 'out.h5')
         self.assertEqual(self.config.output.log_file, '')
         self.assertEqual(self.config.output.spikes_sort_order, Output.SpikesSortOrder.by_id)
@@ -860,9 +860,9 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.connection_override('GABAB_erev').modoverride, None)
         self.assertEqual(self.config.connection_override('GABAB_erev').synapse_configure, '%s.e_GABAA = -82.0 tau_d_GABAB_ProbGABAAB_EMS = 77')
 
-    def test_json(self):
-        temp_config = json.loads(self.config.json)
-        self.assertEqual(temp_config['run']['tstop'], 1000)
+    def test_expanded_json(self):
+        config = json.loads(self.config.expanded_json)
+        self.assertEqual(config['output']['output_dir'], 'some/path/output')
 
 
 if __name__ == '__main__':

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -588,7 +588,7 @@ class CircuitConfig::Parser
         return parsePopulationProperties<EdgePopulation>("edge");
     }
 
-    std::string getExpandedJSON() {
+    std::string getExpandedJSON() const {
         return _json.dump();
     }
 
@@ -1030,15 +1030,19 @@ class SimulationConfig::Parser
         return result;
     }
 
+    std::string getExpandedJSON() const {
+        return _json.dump();
+    }
+
   private:
     const fs::path _basePath;
     nlohmann::json _json;
 };
 
 SimulationConfig::SimulationConfig(const std::string& content, const std::string& basePath)
-    : _jsonContent(content)
-    , _basePath(fs::absolute(basePath).lexically_normal().string()) {
+    : _basePath(fs::absolute(basePath).lexically_normal().string()) {
     const Parser parser(content, basePath);
+    _expandedJSON = parser.getExpandedJSON();
     _run = parser.parseRun();
     _output = parser.parseOutput();
     _conditions = parser.parseConditions();
@@ -1057,10 +1061,6 @@ SimulationConfig SimulationConfig::fromFile(const std::string& path) {
 
 const std::string& SimulationConfig::getBasePath() const noexcept {
     return _basePath;
-}
-
-const std::string& SimulationConfig::getJSON() const noexcept {
-    return _jsonContent;
 }
 
 const SimulationConfig::Run& SimulationConfig::getRun() const noexcept {
@@ -1131,6 +1131,10 @@ const std::string& SimulationConfig::getNodeSetsFile() const noexcept {
 
 const nonstd::optional<std::string>& SimulationConfig::getNodeSet() const noexcept {
     return _nodeSet;
+}
+
+const std::string& SimulationConfig::getExpandedJSON() const {
+    return _expandedJSON;
 }
 
 }  // namespace sonata

--- a/tests/data/config/simulation_config.json
+++ b/tests/data/config/simulation_config.json
@@ -1,6 +1,6 @@
 {
      "manifest": {
-         "$OUTPUT_DIR": "."
+         "$OUTPUT_DIR": "./some/path"
      },
      "target_simulator": "CORENEURON",
      "node_set" : "Column",

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -314,8 +314,8 @@ TEST_CASE("SimulationConfig") {
             fs::path("./data/config/simulation_config.json").parent_path());
 
         CHECK_NOTHROW(config.getOutput());
-        const auto outputPath = fs::absolute(basePath / fs::path("output"));
-        CHECK(config.getOutput().outputDir == outputPath.lexically_normal());
+        const auto outputPath = fs::absolute(basePath / "some/path/output");
+        CHECK(config.getOutput().outputDir == (outputPath).lexically_normal());
         CHECK(config.getOutput().spikesFile == "out.h5");
         CHECK(config.getOutput().logFile.empty());
         CHECK(config.getOutput().sortOrder == SimulationConfig::Output::SpikesSortOrder::by_id);
@@ -354,7 +354,7 @@ TEST_CASE("SimulationConfig") {
         CHECK(config.getReport("cell_imembrane").endTime == 500.);
         CHECK(config.getReport("cell_imembrane").variableName == "i_membrane, IClamp");
 
-        CHECK_NOTHROW(nlohmann::json::parse(config.getJSON()));
+        CHECK_NOTHROW(nlohmann::json::parse(config.getExpandedJSON()));
         CHECK(config.getBasePath() == basePath.lexically_normal());
 
         const auto network = fs::absolute(basePath / fs::path("circuit_config.json"));


### PR DESCRIPTION
* remove the .getJSON method; one can just load the open themselves,
  path resolution is the hard part