### PR TITLE
Migrate missing BlueConfig keys to Sonata

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -367,7 +367,7 @@ class SONATA_API SimulationConfig
             synapse_astrocyte,
             endfoot,
             neuromodulatory,
-            point_neuron
+            point_neuron_tsodyks_markram
         };
 
         /// The location of the file with the spike info for injection

--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -254,7 +254,7 @@ class SONATA_API SimulationConfig
      */
     struct Report {
         enum class Sections { invalid = -1, soma, axon, dend, apic, all };
-        enum class Type { invalid = -1, compartment, summation, synapse };
+        enum class Type { invalid = -1, compartment, summation, synapse, point_neuron };
         enum class Scaling { invalid = -1, none, area };
         enum class Compartments { invalid = -1, center, all };
 
@@ -360,10 +360,23 @@ class SONATA_API SimulationConfig
     struct InputHyperpolarizing: public InputBase {};
 
     struct InputSynapseReplay: public InputBase {
+        enum class ConnectionType {
+            invalid = -1,
+            chemical,
+            electrical,
+            synapse_astrocyte,
+            endfoot,
+            neuromodulatory,
+            point_neuron
+        };
+
         /// The location of the file with the spike info for injection
         std::string spikeFile;
         /// The node set to replay spikes from
         std::string source;
+        /// Type of the connectivity between the source and target of the injection, default =
+        /// chemical
+        ConnectionType connectionType;
     };
 
     struct InputSeclamp: public InputBase {
@@ -508,6 +521,12 @@ class SONATA_API SimulationConfig
         /// Adjustments from weight of this connection_override are applied after the specified
         /// delay has elapsed in ms, default = 0.
         double delay{0.};
+        /// To override the neuromod_dtc values between the selected source and target neurons for
+        /// the neuromodulatory projection
+        nonstd::optional<double> neuromodDtc{nonstd::nullopt};
+        /// To override the neuromod_strength values between the selected source and target neurons
+        /// for the neuromodulatory projection
+        nonstd::optional<double> neuromodStrength{nonstd::nullopt};
     };
     using ConnectionMap = std::unordered_map<std::string, ConnectionOverride>;
 

--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -254,7 +254,7 @@ class SONATA_API SimulationConfig
      */
     struct Report {
         enum class Sections { invalid = -1, soma, axon, dend, apic, all };
-        enum class Type { invalid = -1, compartment, summation, synapse, point_neuron };
+        enum class Type { invalid = -1, compartment, summation, synapse };
         enum class Scaling { invalid = -1, none, area };
         enum class Compartments { invalid = -1, center, all };
 
@@ -366,8 +366,7 @@ class SONATA_API SimulationConfig
             electrical,
             synapse_astrocyte,
             endfoot,
-            neuromodulatory,
-            point_neuron_tsodyks_markram
+            neuromodulatory
         };
 
         /// The location of the file with the spike info for injection
@@ -523,10 +522,10 @@ class SONATA_API SimulationConfig
         double delay{0.};
         /// To override the neuromod_dtc values between the selected source and target neurons for
         /// the neuromodulatory projection
-        nonstd::optional<double> neuromodDtc{nonstd::nullopt};
+        nonstd::optional<double> neuromodulationDtc{nonstd::nullopt};
         /// To override the neuromod_strength values between the selected source and target neurons
         /// for the neuromodulatory projection
-        nonstd::optional<double> neuromodStrength{nonstd::nullopt};
+        nonstd::optional<double> neuromodulationStrength{nonstd::nullopt};
     };
     using ConnectionMap = std::unordered_map<std::string, ConnectionOverride>;
 

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -655,8 +655,7 @@ PYBIND11_MODULE(_libsonata, m) {
     py::enum_<SimulationConfig::Report::Type>(report, "Type")
         .value("compartment", SimulationConfig::Report::Type::compartment)
         .value("summation", SimulationConfig::Report::Type::summation)
-        .value("synapse", SimulationConfig::Report::Type::synapse)
-        .value("point_neuron", SimulationConfig::Report::Type::point_neuron);
+        .value("synapse", SimulationConfig::Report::Type::synapse);
 
     py::enum_<SimulationConfig::Report::Scaling>(report, "Scaling")
         .value("none", SimulationConfig::Report::Scaling::none)
@@ -897,9 +896,7 @@ PYBIND11_MODULE(_libsonata, m) {
                SimulationConfig::InputSynapseReplay::ConnectionType::synapse_astrocyte)
         .value("endfoot", SimulationConfig::InputSynapseReplay::ConnectionType::endfoot)
         .value("neuromodulatory",
-               SimulationConfig::InputSynapseReplay::ConnectionType::neuromodulatory)
-        .value("point_neuron_tsodyks_markram",
-               SimulationConfig::InputSynapseReplay::ConnectionType::point_neuron_tsodyks_markram);
+               SimulationConfig::InputSynapseReplay::ConnectionType::neuromodulatory);
 
     py::class_<SimulationConfig::ConnectionOverride>(m,
                                                      "ConnectionOverride",
@@ -928,12 +925,12 @@ PYBIND11_MODULE(_libsonata, m) {
         .def_readonly("delay",
                       &SimulationConfig::ConnectionOverride::delay,
                       DOC_SIMULATIONCONFIG(ConnectionOverride, delay))
-        .def_readonly("neuromod_dtc",
-                      &SimulationConfig::ConnectionOverride::neuromodDtc,
-                      DOC_SIMULATIONCONFIG(ConnectionOverride, neuromodDtc))
-        .def_readonly("neuromod_strength",
-                      &SimulationConfig::ConnectionOverride::neuromodStrength,
-                      DOC_SIMULATIONCONFIG(ConnectionOverride, neuromodStrength));
+        .def_readonly("neuromodulation_dtc",
+                      &SimulationConfig::ConnectionOverride::neuromodulationDtc,
+                      DOC_SIMULATIONCONFIG(ConnectionOverride, neuromodulationDtc))
+        .def_readonly("neuromodulation_strength",
+                      &SimulationConfig::ConnectionOverride::neuromodulationStrength,
+                      DOC_SIMULATIONCONFIG(ConnectionOverride, neuromodulationStrength));
 
     py::class_<SimulationConfig> simConf(m, "SimulationConfig", "");
     simConf.def(py::init<const std::string&, const std::string&>())

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -898,7 +898,8 @@ PYBIND11_MODULE(_libsonata, m) {
         .value("endfoot", SimulationConfig::InputSynapseReplay::ConnectionType::endfoot)
         .value("neuromodulatory",
                SimulationConfig::InputSynapseReplay::ConnectionType::neuromodulatory)
-        .value("point_neuron", SimulationConfig::InputSynapseReplay::ConnectionType::point_neuron);
+        .value("point_neuron_tsodyks_markram",
+               SimulationConfig::InputSynapseReplay::ConnectionType::point_neuron_tsodyks_markram);
 
     py::class_<SimulationConfig::ConnectionOverride>(m,
                                                      "ConnectionOverride",

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -802,7 +802,7 @@ static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_Connecti
 
 static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_neuromodulatory = R"doc()doc";
 
-static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_point_neuron = R"doc()doc";
+static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_point_neuron_tsodyks_markram = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_synapse_astrocyte = R"doc()doc";
 
@@ -873,6 +873,8 @@ static const char *__doc_bbp_sonata_SimulationConfig_Report_Type = R"doc()doc";
 static const char *__doc_bbp_sonata_SimulationConfig_Report_Type_compartment = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_Report_Type_invalid = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulationConfig_Report_Type_point_neuron = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_Report_Type_summation = R"doc()doc";
 

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -574,11 +574,11 @@ static const char *__doc_bbp_sonata_SimulationConfig_ConnectionOverride_modoverr
 R"doc(Synapse helper files to instantiate the synapses in this
 connection_override, default = None)doc";
 
-static const char *__doc_bbp_sonata_SimulationConfig_ConnectionOverride_neuromodDtc =
+static const char *__doc_bbp_sonata_SimulationConfig_ConnectionOverride_neuromodulationDtc =
 R"doc(To override the neuromod_dtc values between the selected source and
 target neurons for the neuromodulatory projection)doc";
 
-static const char *__doc_bbp_sonata_SimulationConfig_ConnectionOverride_neuromodStrength =
+static const char *__doc_bbp_sonata_SimulationConfig_ConnectionOverride_neuromodulationStrength =
 R"doc(To override the neuromod_strength values between the selected source
 and target neurons for the neuromodulatory projection)doc";
 
@@ -802,8 +802,6 @@ static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_Connecti
 
 static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_neuromodulatory = R"doc()doc";
 
-static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_point_neuron_tsodyks_markram = R"doc()doc";
-
 static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_synapse_astrocyte = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_connectionType =
@@ -873,8 +871,6 @@ static const char *__doc_bbp_sonata_SimulationConfig_Report_Type = R"doc()doc";
 static const char *__doc_bbp_sonata_SimulationConfig_Report_Type_compartment = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_Report_Type_invalid = R"doc()doc";
-
-static const char *__doc_bbp_sonata_SimulationConfig_Report_Type_point_neuron = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_Report_Type_summation = R"doc()doc";
 

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -574,6 +574,14 @@ static const char *__doc_bbp_sonata_SimulationConfig_ConnectionOverride_modoverr
 R"doc(Synapse helper files to instantiate the synapses in this
 connection_override, default = None)doc";
 
+static const char *__doc_bbp_sonata_SimulationConfig_ConnectionOverride_neuromodDtc =
+R"doc(To override the neuromod_dtc values between the selected source and
+target neurons for the neuromodulatory projection)doc";
+
+static const char *__doc_bbp_sonata_SimulationConfig_ConnectionOverride_neuromodStrength =
+R"doc(To override the neuromod_strength values between the selected source
+and target neurons for the neuromodulatory projection)doc";
+
 static const char *__doc_bbp_sonata_SimulationConfig_ConnectionOverride_source = R"doc(node_set specifying presynaptic nodes)doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_ConnectionOverride_spontMinis =
@@ -781,6 +789,26 @@ static const char *__doc_bbp_sonata_SimulationConfig_InputSubthreshold = R"doc()
 static const char *__doc_bbp_sonata_SimulationConfig_InputSubthreshold_percentLess = R"doc(A percentage adjusted from 100 of a cell's threshold current)doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_chemical = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_electrical = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_endfoot = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_invalid = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_neuromodulatory = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_point_neuron = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_ConnectionType_synapse_astrocyte = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_connectionType =
+R"doc(Type of the connectivity between the source and target of the
+injection, default = chemical)doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_source = R"doc(The node set to replay spikes from)doc";
 

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -722,7 +722,7 @@ class TestSimulationConfig(unittest.TestCase):
                                                                             'property3': 0.025}})
 
         self.assertEqual(self.config.list_report_names,
-                         { "adex", "axonal_comp_centers", "cell_imembrane", "compartment", "soma" })
+                         { "axonal_comp_centers", "cell_imembrane", "compartment", "soma" })
 
         self.assertEqual(self.config.report('soma').cells, 'Column')
         self.assertEqual(self.config.report('soma').type, Report.Type.compartment)
@@ -740,8 +740,6 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.report('cell_imembrane').end_time, 500)
         self.assertEqual(self.config.report('cell_imembrane').type.name, 'summation')
         self.assertEqual(self.config.report('cell_imembrane').variable_name, 'i_membrane, IClamp')
-        self.assertEqual(self.config.report('adex').type.name, 'point_neuron')
-        self.assertEqual(self.config.report('adex').variable_name, 'AdEx.V_M, v')
 
         self.assertEqual(self.config.network,
                          os.path.abspath(os.path.join(PATH, 'config/circuit_config.json')))
@@ -831,7 +829,7 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.input('ex_replay').spike_file,
                          os.path.abspath(os.path.join(PATH, 'config/replay.dat')))
         self.assertEqual(self.config.input('ex_replay').source, "ML_afferents")
-        self.assertEqual(self.config.input('ex_replay').connection_type.name, "point_neuron_tsodyks_markram")
+        self.assertEqual(self.config.input('ex_replay').connection_type.name, "electrical")
         self.assertEqual(self.config.input('ex_extracellular_stimulation').node_set, 'Column')
 
         self.assertEqual(self.config.input('ex_abs_shotnoise').input_type.name, "conductance")
@@ -861,15 +859,15 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.connection_override('ConL3Exc-Uni').delay, 0.5)
         self.assertEqual(self.config.connection_override('ConL3Exc-Uni').synapse_delay_override, None)
         self.assertEqual(self.config.connection_override('ConL3Exc-Uni').synapse_configure, None)
-        self.assertEqual(self.config.connection_override('ConL3Exc-Uni').neuromod_dtc, None)
-        self.assertEqual(self.config.connection_override('ConL3Exc-Uni').neuromod_strength, None)
+        self.assertEqual(self.config.connection_override('ConL3Exc-Uni').neuromodulation_dtc, None)
+        self.assertEqual(self.config.connection_override('ConL3Exc-Uni').neuromodulation_strength, None)
         self.assertEqual(self.config.connection_override('GABAB_erev').spont_minis, None)
         self.assertEqual(self.config.connection_override('GABAB_erev').synapse_delay_override, 0.5)
         self.assertEqual(self.config.connection_override('GABAB_erev').delay, 0)
         self.assertEqual(self.config.connection_override('GABAB_erev').modoverride, None)
         self.assertEqual(self.config.connection_override('GABAB_erev').synapse_configure, '%s.e_GABAA = -82.0 tau_d_GABAB_ProbGABAAB_EMS = 77')
-        self.assertEqual(self.config.connection_override('GABAB_erev').neuromod_dtc, 100) 
-        self.assertEqual(self.config.connection_override('GABAB_erev').neuromod_strength, 0.75) 
+        self.assertEqual(self.config.connection_override('GABAB_erev').neuromodulation_dtc, 100) 
+        self.assertEqual(self.config.connection_override('GABAB_erev').neuromodulation_strength, 0.75) 
 
     def test_expanded_json(self):
         config = json.loads(self.config.expanded_json)

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -722,7 +722,7 @@ class TestSimulationConfig(unittest.TestCase):
                                                                             'property3': 0.025}})
 
         self.assertEqual(self.config.list_report_names,
-                         { "axonal_comp_centers", "cell_imembrane", "compartment", "soma" })
+                         { "adex", "axonal_comp_centers", "cell_imembrane", "compartment", "soma" })
 
         self.assertEqual(self.config.report('soma').cells, 'Column')
         self.assertEqual(self.config.report('soma').type, Report.Type.compartment)
@@ -740,6 +740,8 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.report('cell_imembrane').end_time, 500)
         self.assertEqual(self.config.report('cell_imembrane').type.name, 'summation')
         self.assertEqual(self.config.report('cell_imembrane').variable_name, 'i_membrane, IClamp')
+        self.assertEqual(self.config.report('adex').type.name, 'point_neuron')
+        self.assertEqual(self.config.report('adex').variable_name, 'AdEx.V_M, v')
 
         self.assertEqual(self.config.network,
                          os.path.abspath(os.path.join(PATH, 'config/circuit_config.json')))
@@ -829,6 +831,7 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.input('ex_replay').spike_file,
                          os.path.abspath(os.path.join(PATH, 'config/replay.dat')))
         self.assertEqual(self.config.input('ex_replay').source, "ML_afferents")
+        self.assertEqual(self.config.input('ex_replay').connection_type.name, "point_neuron")
         self.assertEqual(self.config.input('ex_extracellular_stimulation').node_set, 'Column')
 
         self.assertEqual(self.config.input('ex_abs_shotnoise').input_type.name, "conductance")
@@ -858,11 +861,15 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.connection_override('ConL3Exc-Uni').delay, 0.5)
         self.assertEqual(self.config.connection_override('ConL3Exc-Uni').synapse_delay_override, None)
         self.assertEqual(self.config.connection_override('ConL3Exc-Uni').synapse_configure, None)
+        self.assertEqual(self.config.connection_override('ConL3Exc-Uni').neuromod_dtc, None)
+        self.assertEqual(self.config.connection_override('ConL3Exc-Uni').neuromod_strength, None)
         self.assertEqual(self.config.connection_override('GABAB_erev').spont_minis, None)
         self.assertEqual(self.config.connection_override('GABAB_erev').synapse_delay_override, 0.5)
         self.assertEqual(self.config.connection_override('GABAB_erev').delay, 0)
         self.assertEqual(self.config.connection_override('GABAB_erev').modoverride, None)
         self.assertEqual(self.config.connection_override('GABAB_erev').synapse_configure, '%s.e_GABAA = -82.0 tau_d_GABAB_ProbGABAAB_EMS = 77')
+        self.assertEqual(self.config.connection_override('GABAB_erev').neuromod_dtc, 100) 
+        self.assertEqual(self.config.connection_override('GABAB_erev').neuromod_strength, 0.75) 
 
     def test_expanded_json(self):
         config = json.loads(self.config.expanded_json)

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -831,7 +831,7 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.input('ex_replay').spike_file,
                          os.path.abspath(os.path.join(PATH, 'config/replay.dat')))
         self.assertEqual(self.config.input('ex_replay').source, "ML_afferents")
-        self.assertEqual(self.config.input('ex_replay').connection_type.name, "point_neuron")
+        self.assertEqual(self.config.input('ex_replay').connection_type.name, "point_neuron_tsodyks_markram")
         self.assertEqual(self.config.input('ex_extracellular_stimulation').node_set, 'Column')
 
         self.assertEqual(self.config.input('ex_abs_shotnoise').input_type.name, "conductance")

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -80,8 +80,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(SimulationConfig::Report::Type,
                              {{SimulationConfig::Report::Type::invalid, nullptr},
                               {SimulationConfig::Report::Type::compartment, "compartment"},
                               {SimulationConfig::Report::Type::summation, "summation"},
-                              {SimulationConfig::Report::Type::synapse, "synapse"},
-                              {SimulationConfig::Report::Type::point_neuron, "point_neuron"}})
+                              {SimulationConfig::Report::Type::synapse, "synapse"}})
 NLOHMANN_JSON_SERIALIZE_ENUM(SimulationConfig::Report::Scaling,
                              {{SimulationConfig::Report::Scaling::invalid, nullptr},
                               {SimulationConfig::Report::Scaling::none, "none"},
@@ -131,9 +130,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(
      {SimulationConfig::InputSynapseReplay::ConnectionType::electrical, "electrical"},
      {SimulationConfig::InputSynapseReplay::ConnectionType::synapse_astrocyte, "synapse_astrocyte"},
      {SimulationConfig::InputSynapseReplay::ConnectionType::endfoot, "endfoot"},
-     {SimulationConfig::InputSynapseReplay::ConnectionType::neuromodulatory, "neuromodulatory"},
-     {SimulationConfig::InputSynapseReplay::ConnectionType::point_neuron_tsodyks_markram,
-      "point_neuron_tsodyks_markram"}})
+     {SimulationConfig::InputSynapseReplay::ConnectionType::neuromodulatory, "neuromodulatory"}})
 
 namespace {
 // to be replaced by std::filesystem once C++17 is used
@@ -1076,8 +1073,8 @@ class SimulationConfig::Parser
             parseOptional(valueIt, "modoverride", connect.modoverride);
             parseOptional(valueIt, "synapse_delay_override", connect.synapseDelayOverride);
             parseOptional(valueIt, "delay", connect.delay);
-            parseOptional(valueIt, "neuromod_dtc", connect.neuromodDtc);
-            parseOptional(valueIt, "neuromod_strength", connect.neuromodStrength);
+            parseOptional(valueIt, "neuromodulation_dtc", connect.neuromodulationDtc);
+            parseOptional(valueIt, "neuromodulation_strength", connect.neuromodulationStrength);
         }
         return result;
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -132,7 +132,8 @@ NLOHMANN_JSON_SERIALIZE_ENUM(
      {SimulationConfig::InputSynapseReplay::ConnectionType::synapse_astrocyte, "synapse_astrocyte"},
      {SimulationConfig::InputSynapseReplay::ConnectionType::endfoot, "endfoot"},
      {SimulationConfig::InputSynapseReplay::ConnectionType::neuromodulatory, "neuromodulatory"},
-     {SimulationConfig::InputSynapseReplay::ConnectionType::point_neuron, "point_neuron"}})
+     {SimulationConfig::InputSynapseReplay::ConnectionType::point_neuron_tsodyks_markram,
+      "point_neuron_tsodyks_markram"}})
 
 namespace {
 // to be replaced by std::filesystem once C++17 is used

--- a/tests/data/config/simulation_config.json
+++ b/tests/data/config/simulation_config.json
@@ -172,7 +172,7 @@
             "spike_file": "replay.dat",
             "source": "ML_afferents",
             "node_set": "Column",
-            "connection_type": "point_neuron_tsodyks_markram"
+            "connection_type": "electrical"
         },
         "ex_extracellular_stimulation": {
             "input_type": "extracellular_stimulation",
@@ -219,8 +219,8 @@
             "weight": 1.0,
             "synapse_delay_override": 0.5,
             "synapse_configure": "%s.e_GABAA = -82.0 tau_d_GABAB_ProbGABAAB_EMS = 77",
-            "neuromod_dtc": 100, 
-            "neuromod_strength": 0.75
+            "neuromodulation_dtc": 100,
+            "neuromodulation_strength": 0.75
         }
     },
     "reports": {
@@ -270,15 +270,6 @@
              "start_time": 0,
              "end_time": 500,
              "enabled": true
-         },
-         "adex": {
-             "cells": "cells2377",
-             "type": "point_neuron",
-             "variable_name": "AdEx.V_M, v",
-             "unit": "mV",
-             "dt": 0.025,
-             "start_time": 0,
-             "end_time": 2100
          }
     }
 }

--- a/tests/data/config/simulation_config.json
+++ b/tests/data/config/simulation_config.json
@@ -172,7 +172,7 @@
             "spike_file": "replay.dat",
             "source": "ML_afferents",
             "node_set": "Column",
-            "connection_type": "point_neuron"
+            "connection_type": "point_neuron_tsodyks_markram"
         },
         "ex_extracellular_stimulation": {
             "input_type": "extracellular_stimulation",

--- a/tests/data/config/simulation_config.json
+++ b/tests/data/config/simulation_config.json
@@ -171,7 +171,8 @@
             "duration": 40000.0,
             "spike_file": "replay.dat",
             "source": "ML_afferents",
-            "node_set": "Column"
+            "node_set": "Column",
+            "connection_type": "point_neuron"
         },
         "ex_extracellular_stimulation": {
             "input_type": "extracellular_stimulation",
@@ -217,7 +218,9 @@
             "target": "Mosaic",
             "weight": 1.0,
             "synapse_delay_override": 0.5,
-            "synapse_configure": "%s.e_GABAA = -82.0 tau_d_GABAB_ProbGABAAB_EMS = 77"
+            "synapse_configure": "%s.e_GABAA = -82.0 tau_d_GABAB_ProbGABAAB_EMS = 77",
+            "neuromod_dtc": 100, 
+            "neuromod_strength": 0.75
         }
     },
     "reports": {
@@ -267,6 +270,15 @@
              "start_time": 0,
              "end_time": 500,
              "enabled": true
+         },
+         "adex": {
+             "cells": "cells2377",
+             "type": "point_neuron",
+             "variable_name": "AdEx.V_M, v",
+             "unit": "mV",
+             "dt": 0.025,
+             "start_time": 0,
+             "end_time": 2100
          }
     }
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -479,8 +479,9 @@ TEST_CASE("SimulationConfig") {
             CHECK(input.nodeSet == "Column");
             CHECK(endswith(input.spikeFile, "replay.dat"));
             CHECK(input.source == "ML_afferents");
-            CHECK(input.connectionType ==
-                  SimulationConfig::InputSynapseReplay::ConnectionType::point_neuron);
+            CHECK(
+                input.connectionType ==
+                SimulationConfig::InputSynapseReplay::ConnectionType::point_neuron_tsodyks_markram);
         }
         {
             const auto input = nonstd::get<SimulationConfig::InputSeclamp>(config.getInput("ex_seclamp"));

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -338,9 +338,9 @@ TEST_CASE("SimulationConfig") {
 
         CHECK_THROWS_AS(config.getReport("DoesNotExist"), SonataError);
 
-        CHECK(config.listReportNames() ==
-              std::set<std::string>{
-                  "adex", "axonal_comp_centers", "cell_imembrane", "compartment", "soma"});
+        CHECK(
+            config.listReportNames() ==
+            std::set<std::string>{"axonal_comp_centers", "cell_imembrane", "compartment", "soma"});
 
         CHECK(config.getReport("soma").cells == "Column");
         CHECK(config.getReport("soma").type == SimulationConfig::Report::Type::compartment);
@@ -358,8 +358,6 @@ TEST_CASE("SimulationConfig") {
               axonalFilePath.lexically_normal());
         CHECK(config.getReport("cell_imembrane").endTime == 500.);
         CHECK(config.getReport("cell_imembrane").variableName == "i_membrane, IClamp");
-        CHECK(config.getReport("adex").type == SimulationConfig::Report::Type::point_neuron);
-        CHECK(config.getReport("adex").variableName == "AdEx.V_M, v");
 
         CHECK_NOTHROW(nlohmann::json::parse(config.getExpandedJSON()));
         CHECK(config.getBasePath() == basePath.lexically_normal());
@@ -479,9 +477,8 @@ TEST_CASE("SimulationConfig") {
             CHECK(input.nodeSet == "Column");
             CHECK(endswith(input.spikeFile, "replay.dat"));
             CHECK(input.source == "ML_afferents");
-            CHECK(
-                input.connectionType ==
-                SimulationConfig::InputSynapseReplay::ConnectionType::point_neuron_tsodyks_markram);
+            CHECK(input.connectionType ==
+                  SimulationConfig::InputSynapseReplay::ConnectionType::electrical);
         }
         {
             const auto input = nonstd::get<SimulationConfig::InputSeclamp>(config.getInput("ex_seclamp"));
@@ -548,16 +545,17 @@ TEST_CASE("SimulationConfig") {
         CHECK(config.getConnectionOverride("ConL3Exc-Uni").delay == 0.5);
         CHECK(config.getConnectionOverride("ConL3Exc-Uni").synapseDelayOverride == nonstd::nullopt);
         CHECK(config.getConnectionOverride("ConL3Exc-Uni").synapseConfigure == nonstd::nullopt);
-        CHECK(config.getConnectionOverride("ConL3Exc-Uni").neuromodDtc == nonstd::nullopt);
-        CHECK(config.getConnectionOverride("ConL3Exc-Uni").neuromodStrength == nonstd::nullopt);
+        CHECK(config.getConnectionOverride("ConL3Exc-Uni").neuromodulationDtc == nonstd::nullopt);
+        CHECK(config.getConnectionOverride("ConL3Exc-Uni").neuromodulationStrength ==
+              nonstd::nullopt);
         CHECK(config.getConnectionOverride("GABAB_erev").spontMinis == nonstd::nullopt);
         CHECK(config.getConnectionOverride("GABAB_erev").synapseDelayOverride == 0.5);
         CHECK(config.getConnectionOverride("GABAB_erev").delay == 0);
         CHECK(config.getConnectionOverride("GABAB_erev").synapseConfigure ==
               "%s.e_GABAA = -82.0 tau_d_GABAB_ProbGABAAB_EMS = 77");
         CHECK(config.getConnectionOverride("GABAB_erev").modoverride == nonstd::nullopt);
-        CHECK(config.getConnectionOverride("GABAB_erev").neuromodDtc == 100);
-        CHECK(config.getConnectionOverride("GABAB_erev").neuromodStrength == 0.75);
+        CHECK(config.getConnectionOverride("GABAB_erev").neuromodulationDtc == 100);
+        CHECK(config.getConnectionOverride("GABAB_erev").neuromodulationStrength == 0.75);
     }
 
     SECTION("manifest_network") {

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -338,12 +338,9 @@ TEST_CASE("SimulationConfig") {
 
         CHECK_THROWS_AS(config.getReport("DoesNotExist"), SonataError);
 
-        CHECK(config.listReportNames() == std::set<std::string>{
-              "axonal_comp_centers",
-              "cell_imembrane",
-              "compartment",
-              "soma"
-              });
+        CHECK(config.listReportNames() ==
+              std::set<std::string>{
+                  "adex", "axonal_comp_centers", "cell_imembrane", "compartment", "soma"});
 
         CHECK(config.getReport("soma").cells == "Column");
         CHECK(config.getReport("soma").type == SimulationConfig::Report::Type::compartment);
@@ -361,6 +358,8 @@ TEST_CASE("SimulationConfig") {
               axonalFilePath.lexically_normal());
         CHECK(config.getReport("cell_imembrane").endTime == 500.);
         CHECK(config.getReport("cell_imembrane").variableName == "i_membrane, IClamp");
+        CHECK(config.getReport("adex").type == SimulationConfig::Report::Type::point_neuron);
+        CHECK(config.getReport("adex").variableName == "AdEx.V_M, v");
 
         CHECK_NOTHROW(nlohmann::json::parse(config.getExpandedJSON()));
         CHECK(config.getBasePath() == basePath.lexically_normal());
@@ -480,6 +479,8 @@ TEST_CASE("SimulationConfig") {
             CHECK(input.nodeSet == "Column");
             CHECK(endswith(input.spikeFile, "replay.dat"));
             CHECK(input.source == "ML_afferents");
+            CHECK(input.connectionType ==
+                  SimulationConfig::InputSynapseReplay::ConnectionType::point_neuron);
         }
         {
             const auto input = nonstd::get<SimulationConfig::InputSeclamp>(config.getInput("ex_seclamp"));
@@ -546,12 +547,16 @@ TEST_CASE("SimulationConfig") {
         CHECK(config.getConnectionOverride("ConL3Exc-Uni").delay == 0.5);
         CHECK(config.getConnectionOverride("ConL3Exc-Uni").synapseDelayOverride == nonstd::nullopt);
         CHECK(config.getConnectionOverride("ConL3Exc-Uni").synapseConfigure == nonstd::nullopt);
+        CHECK(config.getConnectionOverride("ConL3Exc-Uni").neuromodDtc == nonstd::nullopt);
+        CHECK(config.getConnectionOverride("ConL3Exc-Uni").neuromodStrength == nonstd::nullopt);
         CHECK(config.getConnectionOverride("GABAB_erev").spontMinis == nonstd::nullopt);
         CHECK(config.getConnectionOverride("GABAB_erev").synapseDelayOverride == 0.5);
         CHECK(config.getConnectionOverride("GABAB_erev").delay == 0);
         CHECK(config.getConnectionOverride("GABAB_erev").synapseConfigure ==
               "%s.e_GABAA = -82.0 tau_d_GABAB_ProbGABAAB_EMS = 77");
         CHECK(config.getConnectionOverride("GABAB_erev").modoverride == nonstd::nullopt);
+        CHECK(config.getConnectionOverride("GABAB_erev").neuromodDtc == 100);
+        CHECK(config.getConnectionOverride("GABAB_erev").neuromodStrength == 0.75);
     }
 
     SECTION("manifest_network") {


### PR DESCRIPTION
* connection_type in synapse_replay
* neuromod_dtc and neuromod_strength in connection_overrides
* new report type 'point_neuron'