### PR TITLE
make h5 files available through PopulationProperties

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -52,16 +52,20 @@ struct SONATA_API PopulationProperties {
 
     /**
      * Dictionary for alternate directory paths.
+     * It is discouraged to directly access the contents of the file.
+     * Instead use 'libsonata' to read this file.
      */
     std::unordered_map<std::string, std::string> alternateMorphologyFormats;
 
     /**
-     * Path to underlying elements H5 file.  It is discouraged to directly access this.
+     * Path to underlying elements H5 file.
      */
     std::string elementsPath;
 
     /**
-     * Path to underlying types csv file.  It is discouraged to directly access this.
+     * Path to underlying types csv file.
+     * It is discouraged to directly access the contents of the file.
+     * Instead use 'libsonata' to read this file.
      */
     std::string typesPath;
 };

--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -54,6 +54,16 @@ struct SONATA_API PopulationProperties {
      * Dictionary for alternate directory paths.
      */
     std::unordered_map<std::string, std::string> alternateMorphologyFormats;
+
+    /**
+     * Path to underlying elements H5 file.  It is discouraged to directly access this.
+     */
+    std::string elementsPath;
+
+    /**
+     * Path to underlying types csv file.  It is discouraged to directly access this.
+     */
+    std::string typesPath;
 };
 
 /**

--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -52,13 +52,13 @@ struct SONATA_API PopulationProperties {
 
     /**
      * Dictionary for alternate directory paths.
-     * It is discouraged to directly access the contents of the file.
-     * Instead use 'libsonata' to read this file.
      */
     std::unordered_map<std::string, std::string> alternateMorphologyFormats;
 
     /**
      * Path to underlying elements H5 file.
+     * It is discouraged to directly access the contents of the file.
+     * Instead use 'libsonata' to read this file.
      */
     std::string elementsPath;
 

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -509,7 +509,13 @@ PYBIND11_MODULE(_libsonata, m) {
                       DOC_POPULATION_PROPERTIES(morphologiesDir))
         .def_readonly("alternate_morphology_formats",
                       &PopulationProperties::alternateMorphologyFormats,
-                      DOC_POPULATION_PROPERTIES(alternateMorphologyFormats));
+                      DOC_POPULATION_PROPERTIES(alternateMorphologyFormats))
+        .def_readonly("elements_path",
+                      &PopulationProperties::elementsPath,
+                      DOC_POPULATION_PROPERTIES(elementsPath))
+        .def_readonly("types_path",
+                      &PopulationProperties::typesPath,
+                      DOC_POPULATION_PROPERTIES(typesPath));
 
     py::class_<CircuitConfig>(m, "CircuitConfig", "")
         .def(py::init<const std::string&, const std::string&>())

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -226,13 +226,14 @@ static const char *__doc_bbp_sonata_Population = R"doc()doc";
 
 static const char *__doc_bbp_sonata_PopulationProperties = R"doc(Stores population-specific network information.)doc";
 
-static const char *__doc_bbp_sonata_PopulationProperties_alternateMorphologyFormats = R"doc(Dictionary for alternate directory paths.)doc";
+static const char *__doc_bbp_sonata_PopulationProperties_alternateMorphologyFormats =
+R"doc(Dictionary for alternate directory paths. It is discouraged to
+directly access the contents of the file. Instead use 'libsonata' to
+read this file.)doc";
 
 static const char *__doc_bbp_sonata_PopulationProperties_biophysicalNeuronModelsDir = R"doc(Path to the template HOC files defining the E-Mode)doc";
 
-static const char *__doc_bbp_sonata_PopulationProperties_elementsPath =
-R"doc(Path to underlying elements H5 file. It is discouraged to directly
-access this.)doc";
+static const char *__doc_bbp_sonata_PopulationProperties_elementsPath = R"doc(Path to underlying elements H5 file.)doc";
 
 static const char *__doc_bbp_sonata_PopulationProperties_morphologiesDir = R"doc(Path to the directory containing the morphologies)doc";
 
@@ -240,7 +241,8 @@ static const char *__doc_bbp_sonata_PopulationProperties_type = R"doc(Population
 
 static const char *__doc_bbp_sonata_PopulationProperties_typesPath =
 R"doc(Path to underlying types csv file. It is discouraged to directly
-access this.)doc";
+access the contents of the file. Instead use 'libsonata' to read this
+file.)doc";
 
 static const char *__doc_bbp_sonata_PopulationStorage = R"doc(Collection of {PopulationClass}s stored in a H5 file and optional CSV.)doc";
 

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -226,14 +226,14 @@ static const char *__doc_bbp_sonata_Population = R"doc()doc";
 
 static const char *__doc_bbp_sonata_PopulationProperties = R"doc(Stores population-specific network information.)doc";
 
-static const char *__doc_bbp_sonata_PopulationProperties_alternateMorphologyFormats =
-R"doc(Dictionary for alternate directory paths. It is discouraged to
-directly access the contents of the file. Instead use 'libsonata' to
-read this file.)doc";
+static const char *__doc_bbp_sonata_PopulationProperties_alternateMorphologyFormats = R"doc(Dictionary for alternate directory paths.)doc";
 
 static const char *__doc_bbp_sonata_PopulationProperties_biophysicalNeuronModelsDir = R"doc(Path to the template HOC files defining the E-Mode)doc";
 
-static const char *__doc_bbp_sonata_PopulationProperties_elementsPath = R"doc(Path to underlying elements H5 file.)doc";
+static const char *__doc_bbp_sonata_PopulationProperties_elementsPath =
+R"doc(Path to underlying elements H5 file. It is discouraged to directly
+access the contents of the file. Instead use 'libsonata' to read this
+file.)doc";
 
 static const char *__doc_bbp_sonata_PopulationProperties_morphologiesDir = R"doc(Path to the directory containing the morphologies)doc";
 

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -230,9 +230,17 @@ static const char *__doc_bbp_sonata_PopulationProperties_alternateMorphologyForm
 
 static const char *__doc_bbp_sonata_PopulationProperties_biophysicalNeuronModelsDir = R"doc(Path to the template HOC files defining the E-Mode)doc";
 
+static const char *__doc_bbp_sonata_PopulationProperties_elementsPath =
+R"doc(Path to underlying elements H5 file. It is discouraged to directly
+access this.)doc";
+
 static const char *__doc_bbp_sonata_PopulationProperties_morphologiesDir = R"doc(Path to the directory containing the morphologies)doc";
 
 static const char *__doc_bbp_sonata_PopulationProperties_type = R"doc(Population type)doc";
+
+static const char *__doc_bbp_sonata_PopulationProperties_typesPath =
+R"doc(Path to underlying types csv file. It is discouraged to directly
+access this.)doc";
 
 static const char *__doc_bbp_sonata_PopulationStorage = R"doc(Collection of {PopulationClass}s stored in a H5 file and optional CSV.)doc";
 
@@ -557,10 +565,6 @@ static const char *__doc_bbp_sonata_SimulationConfig_Conditions_mechanisms =
 R"doc(Properties to assign values to variables in synapse MOD files. The
 format is a dictionary with keys being the SUFFIX names and values
 being dictionaries of variables' names and values.)doc";
-
-static const char *__doc_bbp_sonata_SimulationConfig_Conditions_minisSingleVesicle =
-R"doc(Limit spontaneous release to single vesicle when true. Default is
-false)doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_Conditions_modifications =
 R"doc(Collection of dictionaries with each member decribing a modification

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -571,11 +571,17 @@ class TestCircuitConfig(unittest.TestCase):
         self.assertTrue(node_prop.biophysical_neuron_models_dir.endswith('biophysical_neuron_models'))
         self.assertEqual(node_prop.alternate_morphology_formats, {})
 
+        self.assertEqual(node_prop.types_path, '')
+        self.assertTrue(node_prop.elements_path.endswith('tests/data/nodes1.h5'))
+
         edge_prop = self.config.edge_population_properties('edges-AC')
         self.assertEqual(edge_prop.type, 'chemical_synapse')
         self.assertTrue(edge_prop.morphologies_dir.endswith('morphologies'))
         self.assertTrue(edge_prop.biophysical_neuron_models_dir.endswith('biophysical_neuron_models'))
         self.assertEqual(edge_prop.alternate_morphology_formats, {})
+
+        self.assertEqual(edge_prop.types_path, '')
+        self.assertTrue(edge_prop.elements_path.endswith('tests/data/edges1.h5'))
 
 
     def test_biophysical_properties_raises(self):

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -137,8 +137,8 @@ namespace fs = ghc::filesystem;
 void checkBiophysicalPopulations(
     const std::unordered_map<std::string, PopulationProperties>& populations) {
     for (const auto& it : populations) {
-        const auto population = it.first;
-        const auto properties = it.second;
+        const auto& population = it.first;
+        const auto& properties = it.second;
         if (properties.type == "biophysical") {
             if (properties.morphologiesDir.empty() &&
                 properties.alternateMorphologyFormats.empty()) {

--- a/tests/data/config/circuit_config.json
+++ b/tests/data/config/circuit_config.json
@@ -14,13 +14,21 @@
     "nodes": [
       {
         "nodes_file": "$NETWORK_DIR/nodes1.h5",
-        "node_types_file": null
+        "node_types_file": null,
+        "populations": {
+            "nodes-A": {},
+            "nodes-B": {}
+        }
       }
     ],
     "edges": [
       {
         "edges_file": "$NETWORK_DIR/edges1.h5",
-        "edge_types_file": null
+        "edge_types_file": null,
+        "populations": {
+            "edges-AB": {},
+            "edges-AC": {}
+        }
       }
     ]
   }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -41,7 +41,12 @@ TEST_CASE("CircuitConfig") {
         CHECK_THROWS_AS(config.getEdgePopulationProperties("DoesNotExist"), SonataError);
 
         CHECK(config.getNodePopulationProperties("nodes-A").type == "biophysical");
+        CHECK(endswith(config.getNodePopulationProperties("nodes-A").typesPath, ""));
+        CHECK(endswith(config.getNodePopulationProperties("nodes-A").elementsPath, "tests/data/nodes1.h5"));
+
         CHECK(config.getEdgePopulationProperties("edges-AB").type == "chemical_synapse");
+        CHECK(endswith(config.getEdgePopulationProperties("edges-AB").typesPath, ""));
+        CHECK(endswith(config.getEdgePopulationProperties("edges-AB").elementsPath, "tests/data/edges1.h5"));
 
         CHECK_NOTHROW(nlohmann::json::parse(config.getExpandedJSON()));
         CHECK(nlohmann::json::parse(config.getExpandedJSON())


### PR DESCRIPTION
* circuit_config.json must now conform to the BBP standard for populations to be found
* the circuit_config.json now is the ground truth for available properties: if multiple nodes files contain the same population name, only the one referenced in the circuit_config.json is considered