### PR TITLE
Fix #226 for empty selections.

### DIFF
--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -248,10 +248,12 @@ class TestEdgePopulation(unittest.TestCase):
     def test_source_nodes(self):
         self.assertEqual(self.test_obj.source_node(1), 1)
         self.assertEqual(self.test_obj.source_nodes(Selection([0, 1, 2, 4])).tolist(), [1, 1, 2, 3])
+        self.assertEqual(self.test_obj.source_nodes(Selection([])).tolist(), [])
 
     def test_target_nodes(self):
         self.assertEqual(self.test_obj.target_node(1), 2)
         self.assertEqual(self.test_obj.target_nodes(Selection([0, 1, 2, 4])).tolist(), [1, 2, 1, 0])
+        self.assertEqual(self.test_obj.target_nodes(Selection([])).tolist(), [])
 
     def test_afferent_edges(self):
         self.assertEqual(self.test_obj.afferent_edges([1, 2]).ranges, [(0, 4), (5, 6)])

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -166,6 +166,14 @@ class TestNodePopulation(unittest.TestCase):
         self.assertEqual(
             self.test_obj.get_attribute(
                 "E-mapping-good",
+                Selection([])
+            ).tolist(),
+            []
+        )
+
+        self.assertEqual(
+            self.test_obj.get_attribute(
+                "E-mapping-good",
                 Selection([(0, 1), (2, 3)])
             ).tolist(),
             ["C", "C"]

--- a/src/population.hpp
+++ b/src/population.hpp
@@ -89,7 +89,9 @@ std::vector<T> _readSelection(const HighFive::DataSet& dset, const Selection& se
 
 template <typename T, typename std::enable_if<std::is_pod<T>::value>::type* = nullptr>
 std::vector<T> _readSelection(const HighFive::DataSet& dset, const Selection& selection) {
-    if (selection.ranges().size() == 1) {
+    if (selection.ranges().empty()) {
+        return {};
+    } else if (selection.ranges().size() == 1) {
         return _readChunk<T>(dset, selection.ranges().front());
     }
 

--- a/tests/test_nodes.cpp
+++ b/tests/test_nodes.cpp
@@ -38,6 +38,8 @@ TEST_CASE("NodePopulation", "[base]") {
     REQUIRE(population.enumerationNames() ==
             std::set<std::string>{"E-mapping-good", "E-mapping-bad"});
 
+    CHECK(population.getAttribute<double>("attr-X", Selection({})) ==
+          std::vector<double>{});
     CHECK(population.getAttribute<double>("attr-X", Selection({{0, 1}, {5, 6}})) ==
           std::vector<double>{11.0, 16.0});
     CHECK(population.getAttribute<float>("attr-X", Selection({{0, 1}})) ==


### PR DESCRIPTION
Part of our software uses empty selections to extract the datatype from the returned Numpy arrays. But with #226, HDF5 does not like the created empty HDF5 slabs, so return directly when nothing is requested.