### PR TITLE
Handle empty selections in source_nodes and target_nodes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,7 @@ SpikeReader
    >>> spikes = libsonata.SpikeReader('path/to/H5/file')
 
    # list populations
-   >>> spikes.get_populations_names()
+   >>> spikes.get_population_names()
 
    # open population
    >>> population = spikes['<name>']
@@ -232,7 +232,7 @@ SomaReportReader
    >>> somas = libsonata.SomaReportReader('path/to/H5/file')
 
    # list populations
-   >>> somas.get_populations_names()
+   >>> somas.get_population_names()
 
    # open population
    >>> population_somas = somas['<name>']
@@ -298,7 +298,7 @@ ElementReportReader
    >>> elements = libsonata.ElementReportReader('path/to/H5/file')
 
    # list populations
-   >>> elements.get_populations_names()
+   >>> elements.get_population_names()
 
    # open population
    >>> population_elements = elements['<name>']

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -240,10 +240,12 @@ class TestEdgePopulation(unittest.TestCase):
     def test_source_nodes(self):
         self.assertEqual(self.test_obj.source_node(1), 1)
         self.assertEqual(self.test_obj.source_nodes(Selection([0, 1, 2, 4])).tolist(), [1, 1, 2, 3])
+        self.assertEqual(self.test_obj.source_nodes(Selection([])).tolist(), [])
 
     def test_target_nodes(self):
         self.assertEqual(self.test_obj.target_node(1), 2)
         self.assertEqual(self.test_obj.target_nodes(Selection([0, 1, 2, 4])).tolist(), [1, 2, 1, 0])
+        self.assertEqual(self.test_obj.target_nodes(Selection([])).tolist(), [])
 
     def test_afferent_edges(self):
         self.assertEqual(self.test_obj.afferent_edges([1, 2]).ranges, [(0, 4), (5, 6)])

--- a/src/population.hpp
+++ b/src/population.hpp
@@ -89,6 +89,10 @@ std::vector<T> _readSelection(const HighFive::DataSet& dset, const Selection& se
 
 template <typename T, typename std::enable_if<std::is_pod<T>::value>::type* = nullptr>
 std::vector<T> _readSelection(const HighFive::DataSet& dset, const Selection& selection) {
+    if (selection.ranges().size() == 0) {
+        return std::vector<T>();
+    }
+
     if (selection.ranges().size() == 1) {
         return _readChunk<T>(dset, selection.ranges().front());
     }


### PR DESCRIPTION
Other:
* replace get_populations_names with get_population_names in README.rst