### PR TITLE
Allow for partial circuit configs

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -76,7 +76,20 @@ struct SONATA_API PopulationProperties {
 class SONATA_API CircuitConfig
 {
   public:
-    enum class Type { invalid, Complete, Partial };
+    enum class ConfigStatus {
+        /// needed for parsing json contents that are null / not an enum value
+        invalid,
+        /// all mandatory properties exist, and the the config should return
+        /// correct values in all possible cases
+        Complete,
+        /**
+         * Partial configs relax the requirements:
+             - can be missing the top level networks key
+             - can be missing the nodes and edges properties under network
+             - mandatory properties aren't enforced (for example for biophysical circuits)
+         */
+        Partial
+    };
 
     /**
      * Parses a SONATA JSON config file.
@@ -103,9 +116,10 @@ class SONATA_API CircuitConfig
     static CircuitConfig fromFile(const std::string& path);
 
     /**
-     * Returns the path to the node sets file.
+     * Returns the `completeness` of the checks that are performed for the
+     * circuit; see `ConfigStatus` for more information
      */
-    Type getCircuitConfigType() const;
+    ConfigStatus getCircuitConfigStatus() const;
 
     /**
      * Returns the path to the node sets file.
@@ -181,8 +195,8 @@ class SONATA_API CircuitConfig
     // manifest variables
     std::string _expandedJSON;
 
-    // Config Type
-    Type _circuitType = Type::Complete;
+    /// How strict we are checking the circuit config
+    ConfigStatus _status = ConfigStatus::Complete;
 
     // Path to the nodesets file
     std::string _nodeSetsFile;

--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -76,6 +76,8 @@ struct SONATA_API PopulationProperties {
 class SONATA_API CircuitConfig
 {
   public:
+    enum class Type { invalid, Complete, Partial };
+
     /**
      * Parses a SONATA JSON config file.
      *
@@ -99,6 +101,11 @@ class SONATA_API CircuitConfig
      *          - Multiple populations with the same name in different edge/node networks
      */
     static CircuitConfig fromFile(const std::string& path);
+
+    /**
+     * Returns the path to the node sets file.
+     */
+    Type getCircuitConfigType() const;
 
     /**
      * Returns the path to the node sets file.
@@ -174,11 +181,14 @@ class SONATA_API CircuitConfig
     // manifest variables
     std::string _expandedJSON;
 
+    // Config Type
+    Type _circuitType = Type::Complete;
+
     // Path to the nodesets file
     std::string _nodeSetsFile;
 
-    // Default components value for all networks
-    Components _components;
+    // Nodes network paths
+    std::vector<SubnetworkFiles> _networkNodes;
 
     // Node populations that override default components variables
     std::unordered_map<std::string, PopulationProperties> _nodePopulationProperties;

--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -81,14 +81,14 @@ class SONATA_API CircuitConfig
         invalid,
         /// all mandatory properties exist, and the the config should return
         /// correct values in all possible cases
-        Complete,
+        complete,
         /**
          * Partial configs relax the requirements:
              - can be missing the top level networks key
              - can be missing the nodes and edges properties under network
              - mandatory properties aren't enforced (for example for biophysical circuits)
          */
-        Partial
+        partial
     };
 
     /**
@@ -196,7 +196,7 @@ class SONATA_API CircuitConfig
     std::string _expandedJSON;
 
     /// How strict we are checking the circuit config
-    ConfigStatus _status = ConfigStatus::Complete;
+    ConfigStatus _status = ConfigStatus::complete;
 
     // Path to the nodesets file
     std::string _nodeSetsFile;

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -517,16 +517,16 @@ PYBIND11_MODULE(_libsonata, m) {
                       &PopulationProperties::typesPath,
                       DOC_POPULATION_PROPERTIES(typesPath));
 
-    py::enum_<CircuitConfig::Type>(m, "CircuitConfigType")
-        .value("invalid", CircuitConfig::Type::invalid)
-        .value("Complete", CircuitConfig::Type::Complete)
-        .value("Partial", CircuitConfig::Type::Partial);
+    py::enum_<CircuitConfig::ConfigStatus>(m, "CircuitConfigStatus")
+        .value("invalid", CircuitConfig::ConfigStatus::invalid)
+        .value("Complete", CircuitConfig::ConfigStatus::Complete)
+        .value("Partial", CircuitConfig::ConfigStatus::Partial);
 
     py::class_<CircuitConfig>(m, "CircuitConfig", "")
         .def(py::init<const std::string&, const std::string&>())
         .def_static("from_file",
                     [](py::object path) { return CircuitConfig::fromFile(py::str(path)); })
-        .def_property_readonly("type", &CircuitConfig::getCircuitConfigType)
+        .def_property_readonly("config_status", &CircuitConfig::getCircuitConfigStatus)
         .def_property_readonly("node_sets_path", &CircuitConfig::getNodeSetsPath)
         .def_property_readonly("node_populations", &CircuitConfig::listNodePopulations)
         .def("node_population", &CircuitConfig::getNodePopulation)

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -517,10 +517,16 @@ PYBIND11_MODULE(_libsonata, m) {
                       &PopulationProperties::typesPath,
                       DOC_POPULATION_PROPERTIES(typesPath));
 
+    py::enum_<CircuitConfig::Type>(m, "CircuitConfigType")
+        .value("invalid", CircuitConfig::Type::invalid)
+        .value("Complete", CircuitConfig::Type::Complete)
+        .value("Partial", CircuitConfig::Type::Partial);
+
     py::class_<CircuitConfig>(m, "CircuitConfig", "")
         .def(py::init<const std::string&, const std::string&>())
         .def_static("from_file",
                     [](py::object path) { return CircuitConfig::fromFile(py::str(path)); })
+        .def_property_readonly("type", &CircuitConfig::getCircuitConfigType)
         .def_property_readonly("node_sets_path", &CircuitConfig::getNodeSetsPath)
         .def_property_readonly("node_populations", &CircuitConfig::listNodePopulations)
         .def("node_population", &CircuitConfig::getNodePopulation)

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -519,8 +519,8 @@ PYBIND11_MODULE(_libsonata, m) {
 
     py::enum_<CircuitConfig::ConfigStatus>(m, "CircuitConfigStatus")
         .value("invalid", CircuitConfig::ConfigStatus::invalid)
-        .value("Complete", CircuitConfig::ConfigStatus::Complete)
-        .value("Partial", CircuitConfig::ConfigStatus::Partial);
+        .value("complete", CircuitConfig::ConfigStatus::complete)
+        .value("partial", CircuitConfig::ConfigStatus::partial);
 
     py::class_<CircuitConfig>(m, "CircuitConfig", "")
         .def(py::init<const std::string&, const std::string&>())

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -42,6 +42,20 @@ static const char *__doc_bbp_sonata_CircuitConfig_Components_biophysicalNeuronMo
 
 static const char *__doc_bbp_sonata_CircuitConfig_Components_morphologiesDir = R"doc()doc";
 
+static const char *__doc_bbp_sonata_CircuitConfig_ConfigStatus = R"doc()doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_ConfigStatus_Complete =
+R"doc(all mandatory properties exist, and the the config should return
+correct values in all possible cases)doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_ConfigStatus_Partial =
+R"doc(Partial configs relax the requirements: - can be missing the top level
+networks key - can be missing the nodes and edges properties under
+network - mandatory properties aren't enforced (for example for
+biophysical circuits))doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_ConfigStatus_invalid = R"doc(needed for parsing json contents that are null / not an enum value)doc";
+
 static const char *__doc_bbp_sonata_CircuitConfig_Parser = R"doc()doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_SubnetworkFiles = R"doc()doc";
@@ -51,16 +65,6 @@ static const char *__doc_bbp_sonata_CircuitConfig_SubnetworkFiles_elements = R"d
 static const char *__doc_bbp_sonata_CircuitConfig_SubnetworkFiles_populations = R"doc()doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_SubnetworkFiles_types = R"doc()doc";
-
-static const char *__doc_bbp_sonata_CircuitConfig_Type = R"doc()doc";
-
-static const char *__doc_bbp_sonata_CircuitConfig_Type_Complete = R"doc()doc";
-
-static const char *__doc_bbp_sonata_CircuitConfig_Type_Partial = R"doc()doc";
-
-static const char *__doc_bbp_sonata_CircuitConfig_Type_invalid = R"doc()doc";
-
-static const char *__doc_bbp_sonata_CircuitConfig_circuitType = R"doc()doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_edgePopulationProperties = R"doc()doc";
 
@@ -77,7 +81,9 @@ Throws:
     another entry is present - Multiple populations with the same name
     in different edge/node networks)doc";
 
-static const char *__doc_bbp_sonata_CircuitConfig_getCircuitConfigType = R"doc(Returns the path to the node sets file.)doc";
+static const char *__doc_bbp_sonata_CircuitConfig_getCircuitConfigStatus =
+R"doc(Returns the `completeness` of the checks that are performed for the
+circuit; see `ConfigStatus` for more information)doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_getEdgePopulation =
 R"doc(Creates and returns an EdgePopulation object, initialized from the
@@ -132,6 +138,8 @@ static const char *__doc_bbp_sonata_CircuitConfig_networkNodes = R"doc()doc";
 static const char *__doc_bbp_sonata_CircuitConfig_nodePopulationProperties = R"doc()doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_nodeSetsFile = R"doc()doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_status = R"doc(How strict we are checking the circuit config)doc";
 
 static const char *__doc_bbp_sonata_DataFrame = R"doc()doc";
 

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -44,17 +44,17 @@ static const char *__doc_bbp_sonata_CircuitConfig_Components_morphologiesDir = R
 
 static const char *__doc_bbp_sonata_CircuitConfig_ConfigStatus = R"doc()doc";
 
-static const char *__doc_bbp_sonata_CircuitConfig_ConfigStatus_Complete =
+static const char *__doc_bbp_sonata_CircuitConfig_ConfigStatus_complete =
 R"doc(all mandatory properties exist, and the the config should return
 correct values in all possible cases)doc";
 
-static const char *__doc_bbp_sonata_CircuitConfig_ConfigStatus_Partial =
+static const char *__doc_bbp_sonata_CircuitConfig_ConfigStatus_invalid = R"doc(needed for parsing json contents that are null / not an enum value)doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_ConfigStatus_partial =
 R"doc(Partial configs relax the requirements: - can be missing the top level
 networks key - can be missing the nodes and edges properties under
 network - mandatory properties aren't enforced (for example for
 biophysical circuits))doc";
-
-static const char *__doc_bbp_sonata_CircuitConfig_ConfigStatus_invalid = R"doc(needed for parsing json contents that are null / not an enum value)doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_Parser = R"doc()doc";
 

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -52,7 +52,15 @@ static const char *__doc_bbp_sonata_CircuitConfig_SubnetworkFiles_populations = 
 
 static const char *__doc_bbp_sonata_CircuitConfig_SubnetworkFiles_types = R"doc()doc";
 
-static const char *__doc_bbp_sonata_CircuitConfig_components = R"doc()doc";
+static const char *__doc_bbp_sonata_CircuitConfig_Type = R"doc()doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_Type_Complete = R"doc()doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_Type_Partial = R"doc()doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_Type_invalid = R"doc()doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_circuitType = R"doc()doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_edgePopulationProperties = R"doc()doc";
 
@@ -68,6 +76,8 @@ Throws:
     (in any depth) - Missing entries which become mandatory when
     another entry is present - Multiple populations with the same name
     in different edge/node networks)doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_getCircuitConfigType = R"doc(Returns the path to the node sets file.)doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_getEdgePopulation =
 R"doc(Creates and returns an EdgePopulation object, initialized from the
@@ -116,6 +126,8 @@ networks.)doc";
 static const char *__doc_bbp_sonata_CircuitConfig_listNodePopulations =
 R"doc(Returns a set with all available population names across all the node
 networks.)doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_networkNodes = R"doc()doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_nodePopulationProperties = R"doc()doc";
 

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -31,7 +31,7 @@ class TestCircuitConfig(unittest.TestCase):
 
         self.assertEqual(self.config.edge_population('edges-AB').name, 'edges-AB')
 
-        self.assertEqual(self.config.config_status, CircuitConfigStatus.Complete)
+        self.assertEqual(self.config.config_status, CircuitConfigStatus.complete)
 
     def test_expanded_json(self):
         config = json.loads(self.config.expanded_json)
@@ -67,7 +67,7 @@ class TestCircuitConfig(unittest.TestCase):
 
         contents = { "metadata": { "status": "partial" }, }
         cc = CircuitConfig(json.dumps(contents), PATH)
-        self.assertEqual(cc.config_status, CircuitConfigStatus.Partial)
+        self.assertEqual(cc.config_status, CircuitConfigStatus.partial)
         self.assertEqual(cc.node_populations, set())
         self.assertEqual(cc.edge_populations, set())
 
@@ -76,7 +76,7 @@ class TestCircuitConfig(unittest.TestCase):
             "networks-mispelled": { },
             }
         cc = CircuitConfig(json.dumps(contents), PATH)
-        self.assertEqual(cc.config_status, CircuitConfigStatus.Partial)
+        self.assertEqual(cc.config_status, CircuitConfigStatus.partial)
         self.assertEqual(cc.node_populations, set())
         self.assertEqual(cc.edge_populations, set())
 

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -6,7 +6,7 @@ from libsonata import (CircuitConfig, SimulationConfig, SonataError,
                        )
 
 
-from libsonata._libsonata import Report, Output, Run, CircuitConfigType
+from libsonata._libsonata import Report, Output, Run, CircuitConfigStatus
 
 
 PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -31,7 +31,7 @@ class TestCircuitConfig(unittest.TestCase):
 
         self.assertEqual(self.config.edge_population('edges-AB').name, 'edges-AB')
 
-        self.assertEqual(self.config.type, CircuitConfigType.Complete)
+        self.assertEqual(self.config.config_status, CircuitConfigStatus.Complete)
 
     def test_expanded_json(self):
         config = json.loads(self.config.expanded_json)
@@ -62,26 +62,26 @@ class TestCircuitConfig(unittest.TestCase):
         self.assertTrue(edge_prop.elements_path.endswith('tests/data/edges1.h5'))
 
     def test_partial(self):
-        contents = { "metadata": { "type": "NOT A TYPE" }, }
+        contents = { "metadata": { "status": "NOT A TYPE" }, }
         self.assertRaises(SonataError, CircuitConfig, json.dumps(contents), PATH)
 
-        contents = { "metadata": { "type": "partial" }, }
+        contents = { "metadata": { "status": "partial" }, }
         cc = CircuitConfig(json.dumps(contents), PATH)
-        self.assertEqual(cc.type, CircuitConfigType.Partial)
+        self.assertEqual(cc.config_status, CircuitConfigStatus.Partial)
         self.assertEqual(cc.node_populations, set())
         self.assertEqual(cc.edge_populations, set())
 
         contents = {
-            "metadata": { "type": "partial" },
+            "metadata": { "status": "partial" },
             "networks-mispelled": { },
             }
         cc = CircuitConfig(json.dumps(contents), PATH)
-        self.assertEqual(cc.type, CircuitConfigType.Partial)
+        self.assertEqual(cc.config_status, CircuitConfigStatus.Partial)
         self.assertEqual(cc.node_populations, set())
         self.assertEqual(cc.edge_populations, set())
 
         contents = {
-            "metadata": { "type": "partial" },
+            "metadata": { "status": "partial" },
             "components": {
                 "morphologies_dir": "some/morph/dir",
                 },

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -55,8 +55,8 @@ namespace sonata {
 
 NLOHMANN_JSON_SERIALIZE_ENUM(CircuitConfig::ConfigStatus,
                              {{CircuitConfig::ConfigStatus::invalid, nullptr},
-                              {CircuitConfig::ConfigStatus::Partial, "partial"},
-                              {CircuitConfig::ConfigStatus::Complete, "complete"}})
+                              {CircuitConfig::ConfigStatus::partial, "partial"},
+                              {CircuitConfig::ConfigStatus::complete, "complete"}})
 
 NLOHMANN_JSON_SERIALIZE_ENUM(SimulationConfig::Run::SpikeLocation,
                              {{SimulationConfig::Run::SpikeLocation::invalid, nullptr},
@@ -589,10 +589,10 @@ class CircuitConfig::Parser
 
     ConfigStatus getCircuitConfigStatus() const {
         if (_json.find("metadata") == _json.end()) {
-            return ConfigStatus::Complete;
+            return ConfigStatus::complete;
         }
         const auto& metadata = _json.at("metadata");
-        const auto res = getJSONValue<ConfigStatus>(metadata, "status", {ConfigStatus::Complete});
+        const auto res = getJSONValue<ConfigStatus>(metadata, "status", {ConfigStatus::complete});
 
         if (res == ConfigStatus::invalid) {
             throw SonataError("Invalid value for `metadata::ConfigStatus` in config");
@@ -605,7 +605,7 @@ class CircuitConfig::Parser
                                      CircuitConfig::ConfigStatus ConfigStatus) const {
         // Fail if no network entry is defined
         if (_json.find("networks") == _json.end()) {
-            if (ConfigStatus == CircuitConfig::ConfigStatus::Complete) {
+            if (ConfigStatus == CircuitConfig::ConfigStatus::complete) {
                 throw SonataError("Error parsing config: `networks` not specified");
             } else {
                 return {};
@@ -782,7 +782,7 @@ CircuitConfig::CircuitConfig(const std::string& contents, const std::string& bas
     updateDefaultProperties(_nodePopulationProperties, "biophysical");
     updateDefaultProperties(_edgePopulationProperties, "chemical");
 
-    if (getCircuitConfigStatus() == ConfigStatus::Complete) {
+    if (getCircuitConfigStatus() == ConfigStatus::complete) {
         raiseOnBiophysicalPopulationsErrors(_nodePopulationProperties);
     }
 }


### PR DESCRIPTION
* a partial circuit config has a `metadata` property `type` that is equal to `partial`
* this relaxes some checking that is done on circuit configs:
  * can be missing the top level `networks` key
  * can be missing the `nodes` and `edges` properties under `network`
* mandatory properties aren't enforced (for example biophysical properties don't need a `[alternative_]morphologies_dir`