### PR TITLE
Add `include(Catch)` to CMakeLists.txt.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,12 @@ set(TESTS_SRC
   test_selection.cpp
 )
 
+if(NOT EXTLIB_FROM_SUBMODULES)
+  # When using submodules `include(.../Catch)` is performed
+  # in `extlib/CMakeLists.txt`.
+  include(Catch)
+endif()
+
 add_executable(unittests ${TESTS_SRC})
 target_link_libraries(unittests
     PRIVATE


### PR DESCRIPTION
Without command `catch_discover_tests` is not defined when not using vendored Catch2.

Documentation suggesting we should have that line:
  * (devel) https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md#automatic-test-registration
  * (lastest) https://github.com/catchorg/Catch2/blob/v2.13.10/docs/cmake-integration.md#automatic-test-registration
  * (vendored) https://github.com/catchorg/Catch2/blob/v2.13.6/docs/cmake-integration.md#automatic-test-registration

It also suggest that if Catch isn't located in a standard location one should edit `CMAKE_MODULE_PATH`. However, doing so in `extlib/CMakeLists.txt` wont propagate the change to `tests/CMakeLists.txt`. Therefore, we conditionally include Catch instead.