### PR TITLE
CircuitConfig: add access to the provenance information.

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -188,6 +188,11 @@ class SONATA_API CircuitConfig
     EdgePopulationProperties getEdgePopulationProperties(const std::string& name) const;
 
     /**
+     * Return a dictionary with provenance information.
+     */
+    nonstd::optional<std::unordered_map<std::string, std::string>> getProvenance() const;
+
+    /**
      * Returns the configuration file JSON whose variables have been expanded by the
      * manifest entries.
      */
@@ -198,6 +203,7 @@ class SONATA_API CircuitConfig
         std::string morphologiesDir;
         std::unordered_map<std::string, std::string> alternateMorphologiesDir;
         std::string biophysicalNeuronModelsDir;
+        nonstd::optional<std::unordered_map<std::string, std::string>> provenance{nonstd::nullopt};
     };
 
     class Parser;
@@ -211,6 +217,9 @@ class SONATA_API CircuitConfig
 
     // Path to the nodesets file
     std::string _nodeSetsFile;
+
+    // Provenance
+    nonstd::optional<std::unordered_map<std::string, std::string>> _provenance;
 
     // Node populations that override default components variables
     std::unordered_map<std::string, NodePopulationProperties> _nodePopulationProperties;

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -550,6 +550,7 @@ PYBIND11_MODULE(_libsonata, m) {
         .def("edge_population", &CircuitConfig::getEdgePopulation)
         .def("node_population_properties", &CircuitConfig::getNodePopulationProperties, "name"_a)
         .def("edge_population_properties", &CircuitConfig::getEdgePopulationProperties, "name"_a)
+        .def_property_readonly("provenance", &CircuitConfig::getProvenance)
         .def_property_readonly("expanded_json", &CircuitConfig::getExpandedJSON);
 
     py::class_<SimulationConfig::Run> run(m,

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -33,6 +33,8 @@ class TestCircuitConfig(unittest.TestCase):
 
         self.assertEqual(self.config.config_status, CircuitConfigStatus.complete)
 
+        self.assertEqual(self.config.provenance, {"bioname_dir": "./bioname"})
+
     def test_expanded_json(self):
         config = json.loads(self.config.expanded_json)
         self.assertEqual(config['components']['biophysical_neuron_models_dir'],
@@ -81,6 +83,7 @@ class TestCircuitConfig(unittest.TestCase):
         self.assertEqual(cc.config_status, CircuitConfigStatus.partial)
         self.assertEqual(cc.node_populations, set())
         self.assertEqual(cc.edge_populations, set())
+        self.assertEqual(cc.provenance, None)
 
         contents = {
             "metadata": { "status": "partial" },

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -656,6 +656,12 @@ class CircuitConfig::Parser
         result.biophysicalNeuronModelsDir = getJSONPath(components,
                                                         "biophysical_neuron_models_dir");
 
+        const auto provenance = components.find("provenance");
+        if (provenance != components.end()) {
+            const auto bioname = getJSONPath(*provenance, "bioname_dir");
+            result.provenance = {{"bioname_dir", bioname}};
+        }
+
         return result;
     }
 
@@ -791,6 +797,9 @@ CircuitConfig::CircuitConfig(const std::string& contents, const std::string& bas
     _edgePopulationProperties = parser.parseEdgePopulations(_status);
 
     Components defaultComponents = parser.parseDefaultComponents();
+
+    _provenance = defaultComponents.provenance;
+
     parser.updateDefaultProperties(_nodePopulationProperties, "biophysical", defaultComponents);
     parser.updateDefaultProperties(_edgePopulationProperties, "chemical", defaultComponents);
 
@@ -833,6 +842,10 @@ NodePopulationProperties CircuitConfig::getNodePopulationProperties(const std::s
 
 EdgePopulationProperties CircuitConfig::getEdgePopulationProperties(const std::string& name) const {
     return getPopulationProperties(name, _edgePopulationProperties);
+}
+
+nonstd::optional<std::unordered_map<std::string, std::string>> CircuitConfig::getProvenance() const {
+    return _provenance;
 }
 
 const std::string& CircuitConfig::getExpandedJSON() const {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -762,7 +762,8 @@ class CircuitConfig::Parser
             "node",
             status,
             [&](NodePopulationProperties& popProperties, const nlohmann::json& popData) {
-            popProperties.spatialSegmentIndexDir = getJSONPath(popData, "spatial_segment_index_dir");
+                popProperties.spatialSegmentIndexDir = getJSONPath(popData,
+                                                                   "spatial_segment_index_dir");
             });
     }
 
@@ -772,7 +773,8 @@ class CircuitConfig::Parser
             "edge",
             status,
             [&](EdgePopulationProperties& popProperties, const nlohmann::json& popData) {
-            popProperties.spatialSynapseIndexDir = getJSONPath(popData, "spatial_synapse_index_dir");
+                popProperties.spatialSynapseIndexDir = getJSONPath(popData,
+                                                                   "spatial_synapse_index_dir");
             });
     }
 
@@ -844,7 +846,8 @@ EdgePopulationProperties CircuitConfig::getEdgePopulationProperties(const std::s
     return getPopulationProperties(name, _edgePopulationProperties);
 }
 
-nonstd::optional<std::unordered_map<std::string, std::string>> CircuitConfig::getProvenance() const {
+nonstd::optional<std::unordered_map<std::string, std::string>> CircuitConfig::getProvenance()
+    const {
     return _provenance;
 }
 

--- a/tests/data/config/circuit_config.json
+++ b/tests/data/config/circuit_config.json
@@ -8,6 +8,9 @@
   "components": {
     "morphologies_dir": "$COMPONENT_DIR/morphologies",
     "biophysical_neuron_models_dir": "$COMPONENT_DIR/biophysical_neuron_models"
+    "provenance": {
+      "bioname_dir": "$COMPONENT_DIR/bioname"
+    }
   },
   "node_sets_file": "$BASE_DIR/node_sets.json",
   "networks": {

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -53,6 +53,9 @@ TEST_CASE("CircuitConfig") {
                   .at("components")
                   .at("morphologies_dir")
                   .get<std::string>() == "morphologies");
+
+        CHECK(config.getProvenance().has_value());
+        CHECK(config.getProvenance()->value()["bioname_dir"] == "./bioname");
     }
 
     SECTION("Exception") {

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -55,7 +55,7 @@ TEST_CASE("CircuitConfig") {
                   .get<std::string>() == "morphologies");
 
         CHECK(config.getProvenance().has_value());
-        CHECK(config.getProvenance()->value()["bioname_dir"] == "./bioname");
+        CHECK(config.getProvenance().value()["bioname_dir"] == "./bioname");
     }
 
     SECTION("Exception") {


### PR DESCRIPTION
As mentioned in [the extension
documentation](https://sonata-extension.readthedocs.io/en/latest/sonata_config.html#provenance),
we can store provenance information in the configuration. This PR adds
an accessor.
