### PR TITLE
allow empty lists for `connection_overrides` in simulation config

### DIFF
--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -528,6 +528,20 @@ class TestSimulationConfig(unittest.TestCase):
         config = json.loads(self.config.expanded_json)
         self.assertEqual(config['output']['output_dir'], 'some/path/output')
 
+    def test_empty_connection_overrides(self):
+        contents = """
+        {
+          "manifest": {
+            "$CIRCUIT_DIR": "./circuit"
+          },
+          "network": "$CIRCUIT_DIR/circuit_config.json",
+          "run": { "random_seed": 12345, "dt": 0.05, "tstop": 1000 },
+          "connection_overrides": []
+        }
+        """
+        conf = SimulationConfig(contents, "./")
+        self.assertEqual(conf.connection_overrides(), [])
+
     def test_run(self):
         contents = """
         {
@@ -557,7 +571,7 @@ class TestSimulationConfig(unittest.TestCase):
               },
               "network": "$CIRCUIT_DIR/circuit_config.json",
               "run": { "random_seed": 12345, "dt": 0.05, "tstop": 1000 },
-              "connection_overrides": { }
+              "connection_overrides": {"foo": "bar"}
             }
             """
             SimulationConfig(contents, "./")

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1080,7 +1080,12 @@ class SimulationConfig::Parser
         std::vector<ConnectionOverride> result;
 
         const auto connIt = _json.find("connection_overrides");
-        if (connIt == _json.end()) {
+        // nlohmann::json::flatten().unflatten() converts empty containers to `null`:
+        // https://json.nlohmann.me/api/basic_json/unflatten/#notes
+        // so we can't tell the difference between {} and []; however, since these are
+        // empty, we will assume the intent was to have no connection_overrides and forgo
+        // better error reporting
+        if (connIt == _json.end() || connIt->is_null()) {
             return result;
         }
 


### PR DESCRIPTION
* due to a quirk with how nlohmann::json flatten()/unflatten() work, empty arrays aren't preserved, thus our datatype check was failing to allow empty arrays.  Work around this
* hat tip to anilbey for noticing: https://github.com/BlueBrain/libsonata/issues/262#issuecomment-1532706421