### PR TITLE
Prevent node_set materialization for `@libary` with integers

### DIFF
--- a/python/tests/test_nodesets.py
+++ b/python/tests/test_nodesets.py
@@ -172,3 +172,12 @@ class TestNodePopulationNodeSet(unittest.TestCase):
         j = '''{ "NodeSetCompound0": [] } '''
         sel = NodeSets(j).materialize("NodeSetCompound0", self.population)
         self.assertEqual(sel, Selection([]))
+
+    def test_library_datatype(self):
+        # E-mapping-good is an @library value, we don't want to allow
+        # materialization of @libraries by integers
+        j = json.dumps({"NodeSet0": { "E-mapping-good": 0 }})
+        self.assertRaises(SonataError, NodeSets(j).materialize, "NodeSet0", self.population)
+
+        j = json.dumps({"NodeSet0": { "E-mapping-good": [0, 1, ] }})
+        self.assertRaises(SonataError, NodeSets(j).materialize, "NodeSet0", self.population)

--- a/src/nodes.cpp
+++ b/src/nodes.cpp
@@ -107,6 +107,10 @@ Selection NodePopulation::regexMatch(const std::string& name, const std::string&
 template <typename T>
 Selection NodePopulation::matchAttributeValues(const std::string& attribute,
                                                const std::vector<T>& values) const {
+    if (enumerationNames().count(attribute) > 0) {
+        throw SonataError("Matching a @library enum by non-string");
+    }
+
     auto dtype = impl_->getAttributeDataSet(attribute).getDataType();
     if (is_unsigned_int(dtype) || is_signed_int(dtype)) {
         return _matchAttributeValues<T>(*this, attribute, values);


### PR DESCRIPTION
* If a node_set contains something like:
 {"layer1": {"layer": 1} ...  # < note it's 1 and not a string "1"

this would previously resolved if "layer" was a set of @library strings,
because it would have matched the numeric 1 to the enum-like values stored
in the /nodes/.../0/layer and not /nodes/.../0/@library/layer