### PR TITLE
Extend metadata type to be int, float, bool and string

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -733,7 +733,7 @@ class SONATA_API SimulationConfig
     /**
      * Returns the metadata section
      */
-    const std::unordered_map<std::string, std::string>& getMetaData() const noexcept;
+    const std::unordered_map<std::string, variantValueType>& getMetaData() const noexcept;
 
 
     /**
@@ -774,7 +774,7 @@ class SONATA_API SimulationConfig
     // Name of node set
     nonstd::optional<std::string> _nodeSet{nonstd::nullopt};
     // Remarks on the simulation
-    std::unordered_map<std::string, std::string> _metaData;
+    std::unordered_map<std::string, variantValueType> _metaData;
     // Variables for a new feature in development, to be moved to other sections once in production
     std::unordered_map<std::string, variantValueType> _betaFeatures;
 

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -597,7 +597,8 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(overrides['GABAB_erev'].neuromodulation_dtc, 100)
         self.assertEqual(overrides['GABAB_erev'].neuromodulation_strength, 0.75)
 
-        self.assertEqual(self.config.metadata, {'sim_version': '1', 'note': 'first attempt of simulation'})
+        self.assertEqual(self.config.metadata,
+                         {'sim_version': 1, 'note': 'first attempt of simulation', 'v_float': 0.5, 'v_bool': False})
         self.assertEqual(self.config.beta_features, {'v_str': 'abcd', 'v_int': 10, 'v_float': 0.5, 'v_bool': False})
 
     def test_expanded_json(self):

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1218,14 +1218,16 @@ class SimulationConfig::Parser
         return result;
     }
 
-    std::unordered_map<std::string, std::string> parseMetaData() const {
-        std::unordered_map<std::string, std::string> result;
+    std::unordered_map<std::string, variantValueType> parseMetaData() const {
+        std::unordered_map<std::string, variantValueType> result;
         const auto metaIt = _json.find("metadata");
         if (metaIt == _json.end()) {
             return result;
         }
         for (auto& it : metaIt->items()) {
-            result.insert({it.key(), it.value()});
+            variantValueType res_val;
+            parseVariantType(it.value(), res_val);
+            result.insert({it.key(), res_val});
         }
         return result;
     }
@@ -1339,7 +1341,8 @@ const nonstd::optional<std::string>& SimulationConfig::getNodeSet() const noexce
     return _nodeSet;
 }
 
-const std::unordered_map<std::string, std::string>& SimulationConfig::getMetaData() const noexcept {
+const std::unordered_map<std::string, variantValueType>& SimulationConfig::getMetaData()
+    const noexcept {
     return _metaData;
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1341,8 +1341,8 @@ const nonstd::optional<std::string>& SimulationConfig::getNodeSet() const noexce
     return _nodeSet;
 }
 
-const std::unordered_map<std::string, variantValueType>& SimulationConfig::getMetaData()
-    const noexcept {
+const std::unordered_map<std::string, variantValueType>& SimulationConfig::getMetaData() const
+    noexcept {
     return _metaData;
 }
 

--- a/tests/data/config/simulation_config.json
+++ b/tests/data/config/simulation_config.json
@@ -1,7 +1,9 @@
 {
      "metadata": {
         "note": "first attempt of simulation",
-        "sim_version": "1"
+        "sim_version": 1,
+        "v_float": 0.5,
+        "v_bool": false
      },
      "beta_features": {
         "v_str": "abcd",

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -584,7 +584,7 @@ TEST_CASE("SimulationConfig") {
         CHECK(overrides[1].neuromodulationStrength == 0.75);
         REQUIRE_THAT(config.getMetaData(),
                      Catch::Matchers::Predicate<decltype(config.getMetaData())>(
-                         [](auto& metadata) -> bool {
+                         [](const auto& metadata) -> bool {
                              return metadata.size() == 4 &&
                                     nonstd::get<std::string>(metadata.at("note")) ==
                                         "first attempt of simulation" &&
@@ -595,7 +595,7 @@ TEST_CASE("SimulationConfig") {
                          "metadata matches"));
         REQUIRE_THAT(config.getBetaFeatures(),
                      Catch::Matchers::Predicate<decltype(config.getBetaFeatures())>(
-                         [](auto& features) -> bool {
+                         [](const auto& features) -> bool {
                              return features.size() == 4 &&
                                     nonstd::get<std::string>(features.at("v_str")) == "abcd" &&
                                     nonstd::get<int>(features.at("v_int")) == 10 &&

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -583,7 +583,7 @@ TEST_CASE("SimulationConfig") {
         CHECK(overrides[1].neuromodulationDtc == 100);
         CHECK(overrides[1].neuromodulationStrength == 0.75);
 
-        CHECK(config.getMetaData().size() == 2);
+        CHECK(config.getMetaData().size() == 4);
         CHECK(config.getBetaFeatures().size() == 4);
     }
 

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -582,9 +582,27 @@ TEST_CASE("SimulationConfig") {
         CHECK(overrides[1].modoverride == nonstd::nullopt);
         CHECK(overrides[1].neuromodulationDtc == 100);
         CHECK(overrides[1].neuromodulationStrength == 0.75);
-
-        CHECK(config.getMetaData().size() == 4);
-        CHECK(config.getBetaFeatures().size() == 4);
+        REQUIRE_THAT(config.getMetaData(),
+                     Catch::Matchers::Predicate<decltype(config.getMetaData())>(
+                         [](auto& metadata) -> bool {
+                             return metadata.size() == 4 &&
+                                    nonstd::get<std::string>(metadata.at("note")) ==
+                                        "first attempt of simulation" &&
+                                    nonstd::get<int>(metadata.at("sim_version")) == 1 &&
+                                    nonstd::get<double>(metadata.at("v_float")) == 0.5 &&
+                                    nonstd::get<bool>(metadata.at("v_bool")) == false;
+                         },
+                         "metadata matches"));
+        REQUIRE_THAT(config.getBetaFeatures(),
+                     Catch::Matchers::Predicate<decltype(config.getBetaFeatures())>(
+                         [](auto& features) -> bool {
+                             return features.size() == 4 &&
+                                    nonstd::get<std::string>(features.at("v_str")) == "abcd" &&
+                                    nonstd::get<int>(features.at("v_int")) == 10 &&
+                                    nonstd::get<double>(features.at("v_float")) == 0.5 &&
+                                    nonstd::get<bool>(features.at("v_bool")) == false;
+                         },
+                         "beta features match"));
     }
 
     SECTION("manifest_network_run") {


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/sonata-extension/issues/26