### PR TITLE
Move std::vector methods above scalar methods in bindings

### DIFF
--- a/include/bbp/sonata/report_reader.h
+++ b/include/bbp/sonata/report_reader.h
@@ -28,6 +28,7 @@ struct SONATA_API DataFrame {
 using Spike = std::pair<NodeID, double>;
 using Spikes = std::vector<Spike>;
 
+/// Used to read spike files
 class SONATA_API SpikeReader
 {
   public:
@@ -46,7 +47,7 @@ class SONATA_API SpikeReader
         std::tuple<double, double> getTimes() const;
 
         /**
-         * Return reports for this population.
+         * Return spikes with all those node_ids between 'tstart' and 'tstop'
          */
         Spikes get(const nonstd::optional<Selection>& node_ids = nonstd::nullopt,
                    const nonstd::optional<double>& tstart = nonstd::nullopt,

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -458,7 +458,7 @@ PYBIND11_MODULE(_libsonata, m) {
         .def("__or__", &bbp::sonata::operator|, "Union of selections")
         .def("__and__", &bbp::sonata::operator&, "Intersection of selections")
         .def("__repr__", [](Selection& obj) {
-            const auto ranges = obj.ranges();
+            const auto& ranges = obj.ranges();
             const size_t max_count = 10;
 
             if (ranges.size() < max_count) {
@@ -475,22 +475,6 @@ PYBIND11_MODULE(_libsonata, m) {
     bindPopulationClass<NodePopulation>(m, "NodePopulation", "Collection of nodes with attributes")
         .def(
             "match_values",
-            [](NodePopulation& obj, const std::string& name, const size_t value) {
-                return obj.matchAttributeValues(name, value);
-            },
-            "name"_a,
-            "value"_a,
-            DOC_POP_NODE(matchAttributeValues))
-        .def(
-            "match_values",
-            [](NodePopulation& obj, const std::string& name, const std::string& value) {
-                return obj.matchAttributeValues(name, value);
-            },
-            "name"_a,
-            "value"_a,
-            DOC_POP_NODE(matchAttributeValues))
-        .def(
-            "match_values",
             [](NodePopulation& obj, const std::string& name, const std::vector<size_t>& values) {
                 return obj.matchAttributeValues(name, values);
             },
@@ -503,6 +487,22 @@ PYBIND11_MODULE(_libsonata, m) {
                const std::string& name,
                const std::vector<std::string>& values) {
                 return obj.matchAttributeValues(name, values);
+            },
+            "name"_a,
+            "value"_a,
+            DOC_POP_NODE(matchAttributeValues))
+        .def(
+            "match_values",
+            [](NodePopulation& obj, const std::string& name, const size_t value) {
+                return obj.matchAttributeValues(name, value);
+            },
+            "name"_a,
+            "value"_a,
+            DOC_POP_NODE(matchAttributeValues))
+        .def(
+            "match_values",
+            [](NodePopulation& obj, const std::string& name, const std::string& value) {
+                return obj.matchAttributeValues(name, value);
             },
             "name"_a,
             "value"_a,
@@ -1110,18 +1110,25 @@ PYBIND11_MODULE(_libsonata, m) {
             DOC_POP_EDGE(targetNodeIDs))
         .def(
             "afferent_edges",
+            [](EdgePopulation& obj, const std::vector<NodeID>& target) {
+                return obj.afferentEdges(target);
+            },
+            "target"_a,
+            DOC_POP_EDGE(afferentEdges))
+        .def(
+            "afferent_edges",
             [](EdgePopulation& obj, NodeID target) {
                 return obj.afferentEdges(std::vector<NodeID>{target});
             },
             "target"_a,
             DOC_POP_EDGE(afferentEdges))
         .def(
-            "afferent_edges",
-            [](EdgePopulation& obj, const std::vector<NodeID>& target) {
-                return obj.afferentEdges(target);
+            "efferent_edges",
+            [](EdgePopulation& obj, const std::vector<NodeID>& source) {
+                return obj.efferentEdges(source);
             },
-            "target"_a,
-            DOC_POP_EDGE(afferentEdges))
+            "source"_a,
+            DOC_POP_EDGE(efferentEdges))
         .def(
             "efferent_edges",
             [](EdgePopulation& obj, NodeID source) {
@@ -1130,12 +1137,13 @@ PYBIND11_MODULE(_libsonata, m) {
             "source"_a,
             DOC_POP_EDGE(efferentEdges))
         .def(
-            "efferent_edges",
-            [](EdgePopulation& obj, const std::vector<NodeID>& source) {
-                return obj.efferentEdges(source);
-            },
+            "connecting_edges",
+            [](EdgePopulation& obj,
+               const std::vector<NodeID>& source,
+               const std::vector<NodeID>& target) { return obj.connectingEdges(source, target); },
             "source"_a,
-            DOC_POP_EDGE(efferentEdges))
+            "target"_a,
+            DOC_POP_EDGE(connectingEdges))
         .def(
             "connecting_edges",
             [](EdgePopulation& obj, NodeID source, NodeID target) {
@@ -1145,14 +1153,6 @@ PYBIND11_MODULE(_libsonata, m) {
             "source"_a,
             "target"_a,
             DOC_POP_EDGE(connectingEdges))
-        .def(
-            "connecting_edges",
-            [](EdgePopulation& obj,
-               const std::vector<NodeID>& source,
-               const std::vector<NodeID>& target) { return obj.connectingEdges(source, target); },
-            "source"_a,
-            "target"_a,
-            "Find all edges connecting two given node sets")
         .def_static("write_indices",
                     &EdgePopulation::writeIndices,
                     "h5_filepath"_a,
@@ -1167,7 +1167,7 @@ PYBIND11_MODULE(_libsonata, m) {
     py::class_<SpikeReader::Population>(m, "SpikePopulation", "A population inside a SpikeReader")
         .def("get",
              &SpikeReader::Population::get,
-             "Return spikes with all those node_ids between 'tstart' and 'tstop'",
+             DOC_SPIKEREADER_POP(get),
              "node_ids"_a = nonstd::nullopt,
              "tstart"_a = nonstd::nullopt,
              "tstop"_a = nonstd::nullopt)
@@ -1185,7 +1185,7 @@ PYBIND11_MODULE(_libsonata, m) {
         .def_property_readonly("times",
                                &SpikeReader::Population::getTimes,
                                DOC_SPIKEREADER_POP(getTimes));
-    py::class_<SpikeReader>(m, "SpikeReader", "Used to read spike files")
+    py::class_<SpikeReader>(m, "SpikeReader", DOC(bbp, sonata, SpikeReader))
         .def(py::init([](py::object h5_filepath) { return SpikeReader(py::str(h5_filepath)); }),
              "h5_filepath"_a)
         .def("get_population_names",

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -1146,7 +1146,7 @@ static const char *__doc_bbp_sonata_SonataError = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SonataError_SonataError = R"doc()doc";
 
-static const char *__doc_bbp_sonata_SpikeReader = R"doc()doc";
+static const char *__doc_bbp_sonata_SpikeReader = R"doc(Used to read spike files)doc";
 
 static const char *__doc_bbp_sonata_SpikeReader_Population = R"doc()doc";
 
@@ -1164,7 +1164,7 @@ static const char *__doc_bbp_sonata_SpikeReader_Population_filterNode = R"doc()d
 
 static const char *__doc_bbp_sonata_SpikeReader_Population_filterTimestamp = R"doc()doc";
 
-static const char *__doc_bbp_sonata_SpikeReader_Population_get = R"doc(Return reports for this population.)doc";
+static const char *__doc_bbp_sonata_SpikeReader_Population_get = R"doc(Return spikes with all those node_ids between 'tstart' and 'tstop')doc";
 
 static const char *__doc_bbp_sonata_SpikeReader_Population_getSorting = R"doc(Return the way data are sorted ('none', 'by_id', 'by_time'))doc";
 


### PR DESCRIPTION
* Otherwise, numpy coercion kicks in, and an argument like `np.asarray([42])` gets coerced to 42, the scalar binding is used, and then we convert it to a std::vector internally.
* not only is this inefficient, newer numpy versions emit:

    DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future.
    Ensure you extract a single element from your array before performing this operation.
    (Deprecated NumPy 1.25.)