### PR TITLE
Skip Python 3.12 RC wheel builds

### DIFF
--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 env:
   CIBW_BUILD_VERBOSITY: 3
   CIBW_BUILD: 'cp*'
-  CIBW_SKIP: 'cp35-* cp36-* cp37-* *-musllinux_* *-manylinux_i686'
+  CIBW_SKIP: 'cp35-* cp36-* cp37-* *-musllinux_* *-manylinux_i686 cp312-*'
   CIBW_TEST_COMMAND: ( cd {project}/python/tests; python -m unittest -v )
 
 jobs:


### PR DESCRIPTION
* it was enabled in cibuildwheel:  https://github.com/pypa/cibuildwheel/pull/1565
* however, we won't be uploading these, so we don't need to build them yet.