### PR TITLE
SimulationConfig: node_sets_file default is empty

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -728,8 +728,7 @@ class SONATA_API SimulationConfig
     const SimulationConfig::SimulatorType& getTargetSimulator() const;
 
     /**
-     * Returns the path of node sets file overriding node_sets_file provided in _network,
-     * default is empty in case of no setting in _network
+     * Returns the path of node sets file, default is empty
      */
     const std::string& getNodeSetsFile() const noexcept;
 

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -1116,9 +1116,7 @@ static const char *__doc_bbp_sonata_SimulationConfig_getNodeSet =
 R"doc(Returns the name of node set to be instantiated for the simulation,
 default = None)doc";
 
-static const char *__doc_bbp_sonata_SimulationConfig_getNodeSetsFile =
-R"doc(Returns the path of node sets file overriding node_sets_file provided
-in _network, default is empty in case of no setting in _network)doc";
+static const char *__doc_bbp_sonata_SimulationConfig_getNodeSetsFile = R"doc(Returns the path of node sets file, default is empty)doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_getOutput = R"doc(Returns the Output section of the simulation configuration.)doc";
 

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -470,7 +470,7 @@ class TestSimulationConfig(unittest.TestCase):
                          os.path.abspath(os.path.join(PATH, 'config/circuit_config.json')))
         self.assertEqual(self.config.target_simulator.name, 'CORENEURON');
         circuit_conf = CircuitConfig.from_file(self.config.network);
-        self.assertEqual(self.config.node_sets_file, circuit_conf.node_sets_path);
+        self.assertEqual(self.config.node_sets_file, '');
         self.assertEqual(self.config.node_set, 'Column');
 
         self.assertEqual(self.config.list_input_names,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1090,20 +1090,11 @@ class SimulationConfig::Parser
     }
 
     std::string parseNodeSetsFile() const noexcept {
-        std::string val;
         if (_json.contains("node_sets_file")) {
-            val = _json["node_sets_file"];
-            return toAbsolute(_basePath, val);
-        } else {
-            try {
-                const auto circuitFile = parseNetwork();
-                const auto conf = CircuitConfig::fromFile(circuitFile);
-                return conf.getNodeSetsPath();
-            } catch (...) {
-                // Don't throw CircuitConfig exceptions in SimulationConfig and return empty string
-                return val;
-            }
+            return toAbsolute(_basePath, _json["node_sets_file"]);
         }
+
+        return {};
     }
 
     nonstd::optional<std::string> parseNodeSet() const {

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -394,8 +394,7 @@ TEST_CASE("SimulationConfig") {
         const auto network = fs::absolute(basePath / fs::path("circuit_config.json"));
         CHECK(config.getNetwork() == network.lexically_normal());
         CHECK(config.getTargetSimulator() == SimulationConfig::SimulatorType::CORENEURON);
-        const auto circuit_conf = CircuitConfig::fromFile(config.getNetwork());
-        CHECK(config.getNodeSetsFile() == circuit_conf.getNodeSetsPath());
+        CHECK(config.getNodeSetsFile() == "");
         CHECK(config.getNodeSet() == "Column");
 
         using InputType = SimulationConfig::InputBase::InputType;
@@ -619,6 +618,7 @@ TEST_CASE("SimulationConfig") {
             "$CIRCUIT_DIR": "./circuit"
           },
           "network": "$CIRCUIT_DIR/circuit_config.json",
+          "node_sets_file": "user_nodesets_file.json",
           "run": {
             "random_seed": 12345,
             "dt": 0.05,
@@ -631,7 +631,8 @@ TEST_CASE("SimulationConfig") {
         const auto network = fs::absolute(basePath / "circuit" / fs::path("circuit_config.json"));
         CHECK(config.getNetwork() == network.lexically_normal());
         CHECK(config.getTargetSimulator() == SimulationConfig::SimulatorType::NEURON);  // default
-        CHECK(config.getNodeSetsFile() == "");  // network file is not readable so default empty
+        CHECK(config.getNodeSetsFile() ==
+              fs::absolute(basePath / fs::path("user_nodesets_file.json")).lexically_normal());
         CHECK(config.getNodeSet() == nonstd::nullopt);  // default
         CHECK(config.getRun().stimulusSeed == 0);
         CHECK(config.getRun().ionchannelSeed == 0);


### PR DESCRIPTION
In case that both circuit config and simulation config files set `node_sets_file`, the resolution order will be implemented in `neurodamus` according to the sonata spec.