### PR TITLE
Use `RawIndex = std::vector<std::array<.., 2>>`.

### DIFF
--- a/src/edge_index.cpp
+++ b/src/edge_index.cpp
@@ -11,6 +11,7 @@
 
 #include <bbp/sonata/common.h>
 
+#include <array>
 #include <cstdint>
 #include <set>
 #include <unordered_map>
@@ -23,7 +24,7 @@ namespace edge_index {
 
 namespace {
 
-using RawIndex = std::vector<std::vector<uint64_t>>;
+using RawIndex = std::vector<std::array<uint64_t, 2>>;
 
 const char* const SOURCE_NODE_ID_DSET = "source_node_id";
 const char* const TARGET_NODE_ID_DSET = "target_node_id";


### PR DESCRIPTION
The memory layout of an `std::vector<std::array<...>>` is better than `std::vector<std::vector<...>>`. This allows HighFive to avoid numerous allocations and copies. Additionally, I feel it's simpler because it avoid the ambiguity of rows of differing length, when in fact the `RawIndex` seems to be a vector of ranges.