### PR TITLE
Formatting CI prints diff on failure.

### DIFF
--- a/ci/check_clang_format.sh
+++ b/ci/check_clang_format.sh
@@ -23,5 +23,8 @@ changes=$(git-clang-format 'HEAD~1' $DIRS_TO_FORMAT)
 if [[ $(echo "$changes" | grep -n1 'changed files') ]]; then
     echo "The following files require changes to pass the current clang-format"
     echo "$changes"
+    echo ""
+    echo "This is the diff:"
+    git diff
     exit 1
 fi


### PR DESCRIPTION
As a not very active contributor, it would be convenient if CI told me where I forgot to add that one `" "`. This can be faster than finding out which version of `clang-format` libsonata uses, installing it and then formatting the code. Naturally, in slightly more complex cases one simply needs to install `clang-format`. This mainly decreases the hurdle to submit tiny fixups of typos and the like.

If it doesn't interfere with other peoples workflow, I suggest printing the git diff.