### PR TITLE
Allow disabling coverage for 'Debug'.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,17 @@ project(sonata VERSION ${SONATA_VERSION})
 option(EXTLIB_FROM_SUBMODULES "Use Git submodules for header-only dependencies" OFF)
 option(SONATA_PYTHON "Build Python extensions" OFF)
 option(SONATA_TESTS "Build tests" ON)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(SONATA_ENABLE_COVERAGE_DEFAULT ON)
+else()
+  set(SONATA_ENABLE_COVERAGE_DEFAULT OFF)
+endif()
+option(SONATA_ENABLE_COVERAGE "Enable measuring test coverage." ${SONATA_ENABLE_COVERAGE_DEFAULT})
+
+# For `Findcoverage.cmake` and friends.
+set(ENABLE_COVERAGE ${SONATA_ENABLE_COVERAGE})
+
 option(SONATA_CXX_WARNINGS "Compile C++ with warnings as errors, for glibcxx turn on assertions" ON)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake)
@@ -58,12 +69,6 @@ set(SONATA_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
 set(SONATA_COMPILE_OPTIONS -Wall -Wextra -pedantic)
 if(SONATA_CXX_WARNINGS)
     set(SONATA_COMPILE_OPTIONS ${SONATA_COMPILE_OPTIONS} -Werror -Wp,-D_GLIBCXX_ASSERTIONS)
-endif()
-
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(ENABLE_COVERAGE ON)
-else()
-    set(ENABLE_COVERAGE OFF)
 endif()
 
 # =============================================================================


### PR DESCRIPTION
If the user specifies `-DSONATA_ENABLE_COVERAGE` then that choice is respected. If no choice is made coverage is `On` for `Debug` build; and `Off` otherwise.

Turning off coverage is useful, if one doesn't have `lcov` but still wants a debug build.