### PR TITLE
Simplify `Selection::Selection`.

### DIFF
--- a/include/bbp/sonata/population.h
+++ b/include/bbp/sonata/population.h
@@ -33,8 +33,7 @@ class SONATA_API Selection
     using Range = std::pair<Value, Value>;
     using Ranges = std::vector<Range>;
 
-    explicit Selection(Ranges&& ranges);
-    explicit Selection(const Ranges& ranges);
+    Selection(Ranges ranges);
 
     template <typename Iterator>
     static Selection fromValues(Iterator first, Iterator last);

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -93,14 +93,8 @@ Selection union_(const Ranges& lhs, const Ranges& rhs) {
 }  // namespace detail
 
 
-Selection::Selection(Selection::Ranges&& ranges)
+Selection::Selection(Selection::Ranges ranges)
     : ranges_(std::move(ranges)) {
-    detail::_checkRanges(ranges_);
-}
-
-
-Selection::Selection(const Selection::Ranges& ranges)
-    : ranges_(ranges) {
     detail::_checkRanges(ranges_);
 }
 


### PR DESCRIPTION
The modern pattern for constructors is to accept by value and move. This avoid duplication of the ctor at the (usually) negligible cost of at most one move.