### PR TITLE
API for configuring HDF5 properties.

### DIFF
--- a/include/bbp/sonata/collective_io_options.h
+++ b/include/bbp/sonata/collective_io_options.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#if SONATA_HAS_MPI == 1
+#include <bbp/sonata/io_options.h>
+
+namespace bbp {
+namespace sonata {
+
+class MPIFileAccessOptsImpl: public FileAccessOptsImpl
+{
+  public:
+    MPIFileAccessOptsImpl() = default;
+    MPIFileAccessOptsImpl(MPI_Comm comm, bool collective)
+        : comm(comm)
+        , collective_metadata(collective) {}
+    ~MPIFileAccessOptsImpl() {
+        MPI_Comm_free(&comm);
+    }
+
+    void apply(HighFive::FileAccessProps& fapl) const override {
+        fapl.add(HighFive::MPIOFileAccess{MPI_COMM_WORLD, MPI_INFO_NULL});
+        fapl.add(HighFive::MPIOCollectiveMetadata{collective_metadata});
+    }
+
+  private:
+    MPI_Comm comm_dup(MPI_Comm old_comm) {
+        MPI_Comm new_comm;
+        MPI_Comm_dup(old_comm, &new_comm);
+        return new_comm;
+    }
+
+    MPI_Comm comm = MPI_COMM_NULL;
+    bool collective_metadata = false;
+};
+
+class MPIDataTransferOptsImpl: public DataTransferOptsImpl
+{
+  public:
+    MPIDataTransferOptsImpl() = default;
+    MPIDataTransferOptsImpl(bool collective)
+        : collective_transfer(collective) {}
+
+    void apply(HighFive::DataTransferProps& dxpl) const override {
+        dxpl.add(HighFive::UseCollectiveIO{collective_transfer});
+    }
+
+  private:
+    bool collective_transfer = false;
+};
+
+
+}  // namespace sonata
+}  // namespace bbp
+
+#endif

--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -182,8 +182,8 @@ class SONATA_API CircuitConfig
      *
      * \throws SonataError if the given population does not exist in any node network.
      */
+    NodePopulation getNodePopulation(const std::string& name, const IoOpts& io_opts) const;
     NodePopulation getNodePopulation(const std::string& name) const;
-
     /**
      * Returns a set with all available population names across all the edge networks.
      */
@@ -195,6 +195,7 @@ class SONATA_API CircuitConfig
      *
      * \throws SonataError if the given population does not exist in any edge network.
      */
+    EdgePopulation getEdgePopulation(const std::string& name, const IoOpts& io_opts) const;
     EdgePopulation getEdgePopulation(const std::string& name) const;
 
     /**

--- a/include/bbp/sonata/edges.h
+++ b/include/bbp/sonata/edges.h
@@ -30,6 +30,11 @@ class SONATA_API EdgePopulation: public Population
                    const std::string& csvFilePath,
                    const std::string& name);
 
+    EdgePopulation(const std::string& h5FilePath,
+                   const std::string& csvFilePath,
+                   const std::string& name,
+                   const IoOpts& io_opts);
+
     /**
      * Name of source population extracted from 'source_node_id' dataset
      */

--- a/include/bbp/sonata/io_options.h
+++ b/include/bbp/sonata/io_options.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <mpi.h>
+
+#include <highfive/H5File.hpp>
+
+namespace bbp {
+namespace sonata {
+
+// -- generic -----------------------------------------------------------------
+template <class Hdf5Props>
+class IoOptsImpl
+{
+  public:
+    using hdf5_props_t = Hdf5Props;
+    virtual void apply(hdf5_props_t& fapl) const = 0;
+};
+
+template <class Impl, class Default>
+class IoAspectOpts
+{
+  public:
+    using hdf5_props_t = typename Impl::hdf5_props_t;
+
+    IoAspectOpts()
+        : impl(std::make_shared<Default>()) {}
+    IoAspectOpts(std::shared_ptr<Impl> impl)
+        : impl(std::move(impl)) {}
+
+    void apply(hdf5_props_t& fapl) const {
+        if (impl) {
+            return impl->apply(fapl);
+        }
+        throw SonataError("Invalid IoOpts, `impl == nullptr`.");
+    }
+
+  private:
+    std::shared_ptr<Impl> impl;
+};
+
+// -- FileAccessOpts ----------------------------------------------------------
+using FileAccessOptsImpl = IoOptsImpl<HighFive::FileAccessProps>;
+
+class NoFileAccessOptsImpl: public FileAccessOptsImpl
+{
+  public:
+    void apply(HighFive::FileAccessProps&) const override {}
+};
+
+using FileAccessOpts = IoAspectOpts<FileAccessOptsImpl, NoFileAccessOptsImpl>;
+
+
+// -- TransferOpts ------------------------------------------------------------
+using DataTransferOptsImpl = IoOptsImpl<HighFive::DataTransferProps>;
+
+class NoDataTransferOptsImpl: public DataTransferOptsImpl
+{
+  public:
+    void apply(HighFive::DataTransferProps&) const override {}
+};
+
+using DataTransferOpts = IoAspectOpts<DataTransferOptsImpl, NoDataTransferOptsImpl>;
+
+// -- IoOpts -------------------------------------------------------------------
+class IoOpts: public FileAccessOpts, public DataTransferOpts
+{
+  public:
+    IoOpts() = default;
+    IoOpts(FileAccessOpts file_access_opts, DataTransferOpts data_transfer_opts)
+        : FileAccessOpts(std::move(file_access_opts))
+        , DataTransferOpts(std::move(data_transfer_opts)) {}
+    using DataTransferOpts::apply;
+    using FileAccessOpts::apply;
+};
+
+}  // namespace sonata
+}  // namespace bbp

--- a/include/bbp/sonata/nodes.h
+++ b/include/bbp/sonata/nodes.h
@@ -30,6 +30,11 @@ class SONATA_API NodePopulation: public Population
                    const std::string& csvFilePath,
                    const std::string& name);
 
+    NodePopulation(const std::string& h5FilePath,
+                   const std::string& csvFilePath,
+                   const std::string& name,
+                   const IoOpts& io_opts);
+
     /**
      * Return selection of where attribute values match value
      *

--- a/include/bbp/sonata/population.h
+++ b/include/bbp/sonata/population.h
@@ -19,6 +19,8 @@
 #include <utility>  // std::move
 #include <vector>
 
+#include <bbp/sonata/io_options.h>
+
 
 namespace bbp {
 namespace sonata {
@@ -239,7 +241,8 @@ class SONATA_API Population
     Population(const std::string& h5FilePath,
                const std::string& csvFilePath,
                const std::string& name,
-               const std::string& prefix);
+               const std::string& prefix,
+               const IoOpts& io_opts);
 
     Population(const Population&) = delete;
 
@@ -264,7 +267,12 @@ template <typename Population>
 class SONATA_API PopulationStorage
 {
   public:
-    PopulationStorage(const std::string& h5FilePath, const std::string& csvFilePath = "");
+    PopulationStorage(const std::string& h5FilePath);
+    PopulationStorage(const std::string& h5FilePath, const std::string& csvFilePath);
+    PopulationStorage(const std::string& h5FilePath, const IoOpts& io_opts);
+    PopulationStorage(const std::string& h5FilePath,
+                      const std::string& csvFilePath,
+                      const IoOpts& io_opts);
 
     PopulationStorage(const PopulationStorage&) = delete;
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "oldest-supported-numpy",
     "setuptools",
     "wheel",
+    "mpi4py",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,5 +1,15 @@
 set(SONATA_PYTHON_BUILD ${CMAKE_CURRENT_BINARY_DIR}/libsonata)
 
+add_library(sonata_mpi INTERFACE)
+
+if(DEFINED SONATA_MPI4PY_INCLUDE_DIR)
+    find_package(MPI REQUIRED)
+
+    target_include_directories(sonata_mpi INTERFACE ${SONATA_MPI4PY_INCLUDE_DIR})
+    target_link_libraries(sonata_mpi INTERFACE MPI::MPI_C)
+    target_compile_definitions(sonata_mpi INTERFACE SONATA_HAS_MPI=1)
+endif()
+
 if (EXTLIB_FROM_SUBMODULES)
     add_subdirectory(pybind11 EXCLUDE_FROM_ALL)
 else()
@@ -17,4 +27,5 @@ target_link_libraries(sonata_python
     PRIVATE HighFive
     PRIVATE fmt::fmt-header-only
     PRIVATE pybind11::module
+    PRIVATE sonata_mpi
 )

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -305,11 +305,12 @@ py::class_<Storage> bindStorageClass(py::module& m, const char* clsName, const c
     };
     return py::class_<Storage>(
                m, clsName, imbuePopulationClassName(DOC(bbp, sonata, PopulationStorage)).c_str())
-        .def(py::init([](py::object h5_filepath, py::object csv_filepath) {
-                 return Storage(py::str(h5_filepath), py::str(csv_filepath));
+        .def(py::init([](py::object h5_filepath, py::object csv_filepath, IoOpts io_opts) {
+                 return Storage(py::str(h5_filepath), py::str(csv_filepath), std::move(io_opts));
              }),
              "h5_filepath"_a,
-             "csv_filepath"_a = "")
+             "csv_filepath"_a = "",
+             "io_opts"_a = IoOpts())
         .def_property_readonly("population_names",
                                &Storage::populationNames,
                                imbuePopulationClassName(DOC_POP_STOR(populationNames)).c_str())
@@ -403,6 +404,8 @@ void bindReportReader(py::module& m, const std::string& prefix) {
 
 
 PYBIND11_MODULE(_libsonata, m) {
+    py::class_<IoOpts>(m, "IoOpts").def(py::init([]() { return IoOpts(); }));
+
     py::class_<Selection>(m,
                           "Selection",
                           "ID sequence in the form convenient for querying attributes")
@@ -579,9 +582,19 @@ PYBIND11_MODULE(_libsonata, m) {
         .def_property_readonly("config_status", &CircuitConfig::getCircuitConfigStatus)
         .def_property_readonly("node_sets_path", &CircuitConfig::getNodeSetsPath)
         .def_property_readonly("node_populations", &CircuitConfig::listNodePopulations)
-        .def("node_population", &CircuitConfig::getNodePopulation)
+        .def("node_population",
+             [](const CircuitConfig& config, const std::string& name) {
+                 return config.getNodePopulation(name);
+             })
         .def_property_readonly("edge_populations", &CircuitConfig::listEdgePopulations)
-        .def("edge_population", &CircuitConfig::getEdgePopulation)
+        .def("edge_population",
+             [](const CircuitConfig& config, const std::string& name) {
+                 return config.getEdgePopulation(name);
+             })
+        .def("edge_population",
+             [](const CircuitConfig& config, const std::string& name, IoOpts io_opts) {
+                 return config.getEdgePopulation(name, io_opts);
+             })
         .def("node_population_properties", &CircuitConfig::getNodePopulationProperties, "name"_a)
         .def("edge_population_properties", &CircuitConfig::getEdgePopulationProperties, "name"_a)
         .def_property_readonly("expanded_json", &CircuitConfig::getExpandedJSON);

--- a/python/libsonata/__init__.py
+++ b/python/libsonata/__init__.py
@@ -23,7 +23,8 @@ from libsonata._libsonata import (
     SpikePopulation,
     SpikeReader,
     version,
-    IoOpts
+    IoOpts,
+    make_collective_io_opts
 )
 
 __all__ = [

--- a/python/libsonata/__init__.py
+++ b/python/libsonata/__init__.py
@@ -23,6 +23,7 @@ from libsonata._libsonata import (
     SpikePopulation,
     SpikeReader,
     version,
+    IoOpts
 )
 
 __all__ = [

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,14 @@ class CMakeBuild(build_ext):
             "-DSONATA_VERSION=" + self.distribution.get_version(),
             "-DCMAKE_BUILD_TYPE={}".format(build_type),
             "-DSONATA_CXX_WARNINGS=OFF",
-            '-DPYTHON_EXECUTABLE=' + sys.executable
+            '-DPYTHON_EXECUTABLE=' + sys.executable,
         ]
+
+        try:
+            import mpi4py
+            cmake_args.append("-DSONATA_MPI4PY_INCLUDE_DIR=" + mpi4py.get_include())
+        except ModuleNotFoundError:
+            pass
 
         build_args = ["--config", build_type,
                       "--target", self.target,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -202,9 +202,10 @@ PopulationType getPopulationProperties(
 
 template <typename PopulationType, typename PopulationPropertiesT>
 PopulationType getPopulation(const std::string& populationName,
-                             const std::unordered_map<std::string, PopulationPropertiesT>& src) {
+                             const std::unordered_map<std::string, PopulationPropertiesT>& src,
+                             const IoOpts& io_opts) {
     const auto properties = getPopulationProperties(populationName, src);
-    return PopulationType(properties.elementsPath, properties.typesPath, populationName);
+    return PopulationType(properties.elementsPath, properties.typesPath, populationName, io_opts);
 }
 
 std::map<std::string, std::string> replaceVariables(std::map<std::string, std::string> variables) {
@@ -918,7 +919,12 @@ std::set<std::string> CircuitConfig::listNodePopulations() const {
 }
 
 NodePopulation CircuitConfig::getNodePopulation(const std::string& name) const {
-    return getPopulation<NodePopulation>(name, _nodePopulationProperties);
+    return getNodePopulation(name, IoOpts());
+}
+
+NodePopulation CircuitConfig::getNodePopulation(const std::string& name,
+                                                const IoOpts& io_opts) const {
+    return getPopulation<NodePopulation>(name, _nodePopulationProperties, io_opts);
 }
 
 std::set<std::string> CircuitConfig::listEdgePopulations() const {
@@ -926,7 +932,12 @@ std::set<std::string> CircuitConfig::listEdgePopulations() const {
 }
 
 EdgePopulation CircuitConfig::getEdgePopulation(const std::string& name) const {
-    return getPopulation<EdgePopulation>(name, _edgePopulationProperties);
+    return getPopulation<EdgePopulation>(name, _edgePopulationProperties, IoOpts());
+}
+
+EdgePopulation CircuitConfig::getEdgePopulation(const std::string& name,
+                                                const IoOpts& io_opts) const {
+    return getPopulation<EdgePopulation>(name, _edgePopulationProperties, io_opts);
 }
 
 NodePopulationProperties CircuitConfig::getNodePopulationProperties(const std::string& name) const {

--- a/src/edges.cpp
+++ b/src/edges.cpp
@@ -33,11 +33,17 @@ namespace bbp {
 namespace sonata {
 
 //--------------------------------------------------------------------------------------------------
-
+//
 EdgePopulation::EdgePopulation(const std::string& h5FilePath,
                                const std::string& csvFilePath,
                                const std::string& name)
-    : Population(h5FilePath, csvFilePath, name, ELEMENT) {}
+    : Population(h5FilePath, csvFilePath, name, ELEMENT, IoOpts()) {}
+
+EdgePopulation::EdgePopulation(const std::string& h5FilePath,
+                               const std::string& csvFilePath,
+                               const std::string& name,
+                               const IoOpts& io_opts)
+    : Population(h5FilePath, csvFilePath, name, ELEMENT, io_opts) {}
 
 
 std::string EdgePopulation::source() const {
@@ -59,14 +65,14 @@ std::string EdgePopulation::target() const {
 std::vector<NodeID> EdgePopulation::sourceNodeIDs(const Selection& selection) const {
     HDF5_LOCK_GUARD
     const auto dset = impl_->h5Root.getDataSet(SOURCE_NODE_ID_DSET);
-    return _readSelection<NodeID>(dset, selection);
+    return _readSelection<NodeID>(dset, selection, impl_->io_opts);
 }
 
 
 std::vector<NodeID> EdgePopulation::targetNodeIDs(const Selection& selection) const {
     HDF5_LOCK_GUARD
     const auto dset = impl_->h5Root.getDataSet(TARGET_NODE_ID_DSET);
-    return _readSelection<NodeID>(dset, selection);
+    return _readSelection<NodeID>(dset, selection, impl_->io_opts);
 }
 
 

--- a/src/nodes.cpp
+++ b/src/nodes.cpp
@@ -92,7 +92,13 @@ Selection _filterStringAttribute(const NodePopulation& population,
 NodePopulation::NodePopulation(const std::string& h5FilePath,
                                const std::string& csvFilePath,
                                const std::string& name)
-    : Population(h5FilePath, csvFilePath, name, ELEMENT) {}
+    : NodePopulation(h5FilePath, csvFilePath, name, IoOpts()) {}
+
+NodePopulation::NodePopulation(const std::string& h5FilePath,
+                               const std::string& csvFilePath,
+                               const std::string& name,
+                               const IoOpts& io_opts)
+    : Population(h5FilePath, csvFilePath, name, ELEMENT, io_opts) {}
 
 Selection NodePopulation::regexMatch(const std::string& attribute, const std::string& regex) const {
     std::regex re(regex);

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -194,10 +194,11 @@ std::string _getDataType(const HighFive::DataSet& dset, const std::string& name)
 Population::Population(const std::string& h5FilePath,
                        const std::string& csvFilePath,
                        const std::string& name,
-                       const std::string& prefix)
-    : impl_([h5FilePath, csvFilePath, name, prefix] {
+                       const std::string& prefix,
+                       const IoOpts& io_opts)
+    : impl_([h5FilePath, csvFilePath, name, prefix, io_opts] {
         HDF5_LOCK_GUARD
-        return new Population::Impl(h5FilePath, csvFilePath, name, prefix);
+        return new Population::Impl(h5FilePath, csvFilePath, name, prefix, io_opts);
     }()) {}
 
 
@@ -240,14 +241,14 @@ std::vector<std::string> Population::enumerationValues(const std::string& name) 
 
     // Note: can't use select all, because our locks aren't re-entrant
     const auto selection = Selection({{0, dset.getSpace().getDimensions()[0]}});
-    return _readSelection<std::string>(dset, selection);
+    return _readSelection<std::string>(dset, selection, impl_->io_opts);
 }
 
 
 template <typename T>
 std::vector<T> Population::getAttribute(const std::string& name, const Selection& selection) const {
     HDF5_LOCK_GUARD
-    return _readSelection<T>(impl_->getAttributeDataSet(name), selection);
+    return _readSelection<T>(impl_->getAttributeDataSet(name), selection, impl_->io_opts);
 }
 
 
@@ -256,7 +257,9 @@ std::vector<std::string> Population::getAttribute<std::string>(const std::string
                                                                const Selection& selection) const {
     if (impl_->attributeEnumNames.count(name) == 0) {
         HDF5_LOCK_GUARD
-        return _readSelection<std::string>(impl_->getAttributeDataSet(name), selection);
+        return _readSelection<std::string>(impl_->getAttributeDataSet(name),
+                                           selection,
+                                           impl_->io_opts);
     }
 
     const auto indices = getAttribute<size_t>(name, selection);
@@ -297,7 +300,7 @@ std::vector<T> Population::getEnumeration(const std::string& name,
     }
 
     HDF5_LOCK_GUARD
-    return _readSelection<T>(impl_->getAttributeDataSet(name), selection);
+    return _readSelection<T>(impl_->getAttributeDataSet(name), selection, impl_->io_opts);
 }
 
 
@@ -321,7 +324,7 @@ template <typename T>
 std::vector<T> Population::getDynamicsAttribute(const std::string& name,
                                                 const Selection& selection) const {
     HDF5_LOCK_GUARD
-    return _readSelection<T>(impl_->getDynamicsAttributeDataSet(name), selection);
+    return _readSelection<T>(impl_->getDynamicsAttributeDataSet(name), selection, impl_->io_opts);
 }
 
 

--- a/src/population.hpp
+++ b/src/population.hpp
@@ -110,8 +110,8 @@ std::vector<T> _readSelection(const HighFive::DataSet& dset, const Selection& se
                    std::back_inserter(ids_sorted),
                    [&ids](size_t i) { return static_cast<size_t>(ids[i]); });
 
-    std::vector<T> linear_result(ids_sorted.size());
-    dset.select(HighFive::ElementSet{ids_sorted}).read(linear_result.data());
+    std::vector<T> linear_result;
+    dset.select(HighFive::ElementSet{ids_sorted}).read(linear_result);
 
     std::vector<T> result(ids_sorted.size());
     for (size_t i = 0; i < ids_sorted.size(); ++i) {

--- a/src/population.hpp
+++ b/src/population.hpp
@@ -97,6 +97,7 @@ std::vector<T> _readSelection(const HighFive::DataSet& dset, const Selection& se
 
     const auto ids = selection.flatten();
 
+    // TODO Rewrite to not use IDs but ID ranges.
     std::vector<std::size_t> ids_index(ids.size());
     std::iota(ids_index.begin(), ids_index.end(), std::size_t(0));
     std::stable_sort(ids_index.begin(), ids_index.end(), [&ids](size_t i0, size_t i1) {
@@ -121,17 +122,74 @@ std::vector<T> _readSelection(const HighFive::DataSet& dset, const Selection& se
     return result;
 }
 
+namespace collective {
+template <typename T>
+std::vector<T> _readSelection(const HighFive::DataSet& dset,
+                              const Selection& selection,
+                              const DataTransferOpts& data_transfer_opts) {
+    // TODO Guard existence of MPI, and fall back to regular `_readSelection`.
+    const auto ids = selection.flatten();
+
+    // TODO optimize if canonical.
+    // TODO get the `std::move` twist back for canonical selections
+
+    // TODO Rewrite to not use IDs but ID ranges.
+    std::vector<std::size_t> ids_index(ids.size());
+    std::iota(ids_index.begin(), ids_index.end(), std::size_t(0));
+    std::stable_sort(ids_index.begin(), ids_index.end(), [&ids](size_t i0, size_t i1) {
+        return ids[i0] < ids[i1];
+    });
+
+    std::vector<std::size_t> ids_sorted;
+    ids_sorted.reserve(ids.size());
+    std::transform(ids_index.begin(),
+                   ids_index.end(),
+                   std::back_inserter(ids_sorted),
+                   [&ids](size_t i) { return static_cast<size_t>(ids[i]); });
+
+    std::vector<T> linear_result;
+
+    auto xfer_props = HighFive::DataTransferProps{};
+    data_transfer_opts.apply(xfer_props);
+
+    dset.select(HighFive::ElementSet{ids_sorted}).read(linear_result, xfer_props);
+
+    std::vector<T> result(ids_sorted.size());
+    for (size_t i = 0; i < ids_sorted.size(); ++i) {
+        result[ids_index[i]] = linear_result[i];
+    }
+
+    return result;
+}
+}  // namespace collective
+
+
+template <typename T>
+std::vector<T> _readSelection(const HighFive::DataSet& dset,
+                              const Selection& selection,
+                              const DataTransferOpts& data_transfer_opts) {
+    return collective::_readSelection<T>(dset, selection, data_transfer_opts);
+}
+
 }  // unnamed namespace
 
+
+inline HighFive::File open_hdf5_file(const std::string& filename,
+                                     const FileAccessOpts& file_access_opts) {
+    HighFive::FileAccessProps fapl;
+    file_access_opts.apply(fapl);
+    return HighFive::File(filename, HighFive::File::ReadOnly, fapl);
+}
 
 struct Population::Impl {
     Impl(const std::string& h5FilePath,
          const std::string&,
          const std::string& _name,
-         const std::string& _prefix)
+         const std::string& _prefix,
+         const IoOpts& io_opts)
         : name(_name)
         , prefix(_prefix)
-        , h5File(h5FilePath)
+        , h5File(open_hdf5_file(h5FilePath, io_opts))
         , h5Root(h5File.getGroup(fmt::format("/{}s", prefix)).getGroup(name))
         , attributeNames(_listChildren(h5Root.getGroup("0"), {H5_DYNAMICS_PARAMS, H5_LIBRARY}))
         , attributeEnumNames(
@@ -142,7 +200,8 @@ struct Population::Impl {
         , dynamicsAttributeNames(
               h5Root.getGroup("0").exist(H5_DYNAMICS_PARAMS)
                   ? _listChildren(h5Root.getGroup("0").getGroup(H5_DYNAMICS_PARAMS))
-                  : std::set<std::string>{}) {
+                  : std::set<std::string>{})
+        , io_opts(io_opts) {
         if (h5Root.exist("1")) {
             throw SonataError("Only single-group populations are supported at the moment");
         }
@@ -176,19 +235,27 @@ struct Population::Impl {
     const std::set<std::string> attributeNames;
     const std::set<std::string> attributeEnumNames;
     const std::set<std::string> dynamicsAttributeNames;
+    const IoOpts io_opts;
 };
 
 //--------------------------------------------------------------------------------------------------
 
 template <typename Population>
 struct PopulationStorage<Population>::Impl {
-    Impl(const std::string& _h5FilePath, const std::string& _csvFilePath)
+    Impl(const std::string& _h5FilePath)
+        : Impl(_h5FilePath, IoOpts()) {}
+
+    Impl(const std::string& _h5FilePath, const IoOpts& io_opts)
+        : Impl(_h5FilePath, std::string(), io_opts) {}
+
+    Impl(const std::string& _h5FilePath, const std::string& _csvFilePath, const IoOpts& io_opts)
         : h5FilePath(_h5FilePath)
         , csvFilePath(_csvFilePath)
         , h5File(h5FilePath)
-        , h5Root(h5File.getGroup(fmt::format("/{}s", Population::ELEMENT))) {
+        , h5Root(h5File.getGroup(fmt::format("/{}s", Population::ELEMENT)))
+        , io_opts(io_opts) {
         if (!csvFilePath.empty()) {
-            throw SonataError("CSV not supported at the moment");
+            throw SonataError(fmt::format("CSV not supported at the moment: {}", csvFilePath));
         }
     }
 
@@ -196,15 +263,30 @@ struct PopulationStorage<Population>::Impl {
     const std::string csvFilePath;
     const HighFive::File h5File;
     const HighFive::Group h5Root;
+    const IoOpts io_opts;
 };
 
+template <typename Population>
+PopulationStorage<Population>::PopulationStorage(const std::string& h5FilePath)
+    : PopulationStorage(h5FilePath, IoOpts()) {}
+
+template <typename Population>
+PopulationStorage<Population>::PopulationStorage(const std::string& h5FilePath,
+                                                 const IoOpts& io_opts)
+    : PopulationStorage(h5FilePath, std::string(), io_opts) {}
 
 template <typename Population>
 PopulationStorage<Population>::PopulationStorage(const std::string& h5FilePath,
                                                  const std::string& csvFilePath)
-    : impl_([h5FilePath, csvFilePath] {
+    : PopulationStorage(h5FilePath, csvFilePath, IoOpts()) {}
+
+template <typename Population>
+PopulationStorage<Population>::PopulationStorage(const std::string& h5FilePath,
+                                                 const std::string& csvFilePath,
+                                                 const IoOpts& io_opts)
+    : impl_([h5FilePath, csvFilePath, io_opts] {
         HDF5_LOCK_GUARD
-        return new PopulationStorage::Impl(h5FilePath, csvFilePath);
+        return new PopulationStorage::Impl(h5FilePath, csvFilePath, io_opts);
     }()) {}
 
 
@@ -233,7 +315,10 @@ std::shared_ptr<Population> PopulationStorage<Population>::openPopulation(
             throw SonataError(fmt::format("No such population: '{}'", name));
         }
     }
-    return std::make_shared<Population>(impl_->h5FilePath, impl_->csvFilePath, name);
+    return std::make_shared<Population>(impl_->h5FilePath,
+                                        impl_->csvFilePath,
+                                        name,
+                                        impl_->io_opts);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/population.hpp
+++ b/src/population.hpp
@@ -143,11 +143,7 @@ struct Population::Impl {
               h5Root.getGroup("0").exist(H5_DYNAMICS_PARAMS)
                   ? _listChildren(h5Root.getGroup("0").getGroup(H5_DYNAMICS_PARAMS))
                   : std::set<std::string>{}) {
-        size_t groupID = 0;
-        while (h5Root.exist(std::to_string(groupID))) {
-            ++groupID;
-        }
-        if (groupID != 1) {
+        if (h5Root.exist("1")) {
             throw SonataError("Only single-group populations are supported at the moment");
         }
     }


### PR DESCRIPTION
This PR consists of two parts, the first introduces new API which would allow developers to inject HDF5 properties (via File Access and Data Transfer Property Lists) for reading. This could be used to select a page buffer for paged HDF5 files, tweaking meta data cache sizes, etc.

It can also be used to inject collective MPI-IO into `libsonata` without making it dependent on MPI. This is sketched out in 0a770925fd3df8b0c1e61ac3795311c4230c0d9c. The entirety of that commit would be moved to a separate repository `libsonata-mpi`; and there would be little to no mention of MPI in `libsonata`.

The way this works is that there's two object `FileAccessOpts` and `DataTransferOpts`, each contains a `shared_ptr` to a polymorphic `*Impl` class. The polymorphic classes have a method:
```
void apply(HighFive::FileAccessProps& fapl);
void apply(HighFive::DataTransferProps& dxpl);
```
(respectively). Which will set the desired properties in the respective Property List.

While we can avoid the dependency on MPI, we do require changes to `libsonata` that make it compatible with MPI-IO. One of them is sketeched out in `collective::_readSelection`. With the new aggregated reading, we can also make `?fferent_edges` collective.

There's a difficulty in packaging. We require that `mpi4py` is a build-time dependency. The issue is that build-time dependencies are both static and mandatory. It is easy to  implement a version of `libsonata-mpi` which doesn't have MPI support. This allows user code which expects MPI-IO works without changes even if `libsonata-mpi` doesn't have MPI-IO support, by simply not performing MPI-IO. The difficulty is that we can't write a `pyproject.toml` or `setup.py` for `libsonata-mpi` that can build either the MPI-enable or MPI-disabled version by simply passing flags or detecting `mpi4py`. What can be done is break build isolation and install all requirements manually, then install `libsonata-mpi` depending on whether `mpi4py` is present, it'll build with or without MPI support. Using Spack we can work around this limitation.