### PR TITLE
Refactor edge_index::resolve.

### DIFF
--- a/src/edge_index.cpp
+++ b/src/edge_index.cpp
@@ -77,7 +77,6 @@ Selection resolve(const HighFive::Group& indexGroup, const std::vector<NodeID>& 
         return range[0] >= range[1];
     });
 
-    // TODO check that the spec allows us to optimize this.
     primaryRange = bulk_read::sortAndMerge(primaryRange);
 
     auto secondaryRange = detail::readCanonicalSelection<std::array<uint64_t, 2>>(

--- a/src/edge_index.cpp
+++ b/src/edge_index.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "read_bulk.hpp"
+#include "read_canonical_selection.hpp"
 
 namespace bbp {
 namespace sonata {
@@ -54,78 +55,33 @@ const HighFive::Group targetIndex(const HighFive::Group& h5Root) {
     return h5Root.getGroup(TARGET_INDEX_GROUP);
 }
 
-Selection resolve(const HighFive::Group& indexGroup, const NodeID nodeID) {
-    if (nodeID >= indexGroup.getDataSet(NODE_ID_TO_RANGES_DSET).getSpace().getDimensions()[0]) {
-        // Returning empty set for out-of-range node IDs, to be aligned with SYN2 reader
-        // implementation
-        // TODO: throw a SonataError instead
-        return Selection({});
-    }
-
-    RawIndex primaryRange;
-    indexGroup.getDataSet(NODE_ID_TO_RANGES_DSET)
-        .select({static_cast<size_t>(nodeID), 0}, {1, 2})
-        .read(primaryRange);
-
-    const uint64_t primaryRangeBegin = primaryRange[0][0];
-    const uint64_t primaryRangeEnd = primaryRange[0][1];
-
-    if (primaryRangeBegin >= primaryRangeEnd) {
-        return Selection({});
-    }
-
-    RawIndex secondaryRange;
-    indexGroup.getDataSet(RANGE_TO_EDGE_ID_DSET)
-        .select({static_cast<size_t>(primaryRangeBegin), 0},
-                {static_cast<size_t>(primaryRangeEnd - primaryRangeBegin), 2})
-        .read(secondaryRange);
-
-    Selection::Ranges ranges;
-    ranges.reserve(secondaryRange.size());
-
-    for (const auto& row : secondaryRange) {
-        ranges.emplace_back(row[0], row[1]);
-    }
-
-    return Selection(std::move(ranges));
-}
-
 Selection resolve(const HighFive::Group& indexGroup, const std::vector<NodeID>& nodeIDs) {
-    constexpr size_t min_gap_size = SONATA_PAGESIZE / (2 * sizeof(uint64_t));
-    constexpr size_t max_aggregated_block_size = 128 * min_gap_size;
+    auto node2ranges_dset = indexGroup.getDataSet(NODE_ID_TO_RANGES_DSET);
+    auto node_dim = node2ranges_dset.getSpace().getDimensions()[0];
+    auto sortedNodeIds = nodeIDs;
+    bulk_read::detail::erase_if(sortedNodeIds, [node_dim](auto id) {
+        // Filter out `nodeIDs[i] >= dims`; because SYN2 used to return an
+        // empty range for an out-of-range `nodeId`s.
+        return id >= node_dim;
+    });
+    std::sort(sortedNodeIds.begin(), sortedNodeIds.end());
+    sortedNodeIds.erase(std::unique(sortedNodeIds.begin(), sortedNodeIds.end()),
+                        sortedNodeIds.end());
 
-    if (nodeIDs.size() == 1) {
-        return resolve(indexGroup, nodeIDs[0]);
-    }
+    auto nodeSelection = Selection::fromValues(sortedNodeIds);
+    auto primaryRange = detail::readCanonicalSelection<std::array<uint64_t, 2>>(
+        node2ranges_dset, nodeSelection.ranges(), RawIndex{{0, 2}});
 
-    auto readBlock = [&indexGroup](auto& buffer, const auto& range, const std::string& dset_name) {
-        size_t i_begin = std::get<0>(range);
-        size_t i_end = std::get<1>(range);
+    bulk_read::detail::erase_if(primaryRange, [](const auto& range) {
+        // Filter out any invalid ranges `start >= end`.
+        return range[0] >= range[1];
+    });
 
-        indexGroup.getDataSet(dset_name).select({i_begin, 0}, {i_end - i_begin, 2}).read(buffer);
-    };
-
-    auto primaryRange = bulk_read::bulkRead<std::array<uint64_t, 2>>(
-        [&readBlock](auto& buffer, const auto& range) {
-            readBlock(buffer, range, NODE_ID_TO_RANGES_DSET);
-        },
-        Selection::fromValues(nodeIDs),
-        min_gap_size,
-        max_aggregated_block_size);
-
-    // Sort and eliminate empty ranges.
+    // TODO check that the spec allows us to optimize this.
     primaryRange = bulk_read::sortAndMerge(primaryRange);
-    if (primaryRange.empty()) {
-        return Selection({});
-    }
 
-    auto secondaryRange = bulk_read::bulkRead<std::array<uint64_t, 2>>(
-        [&readBlock](auto& buffer, const auto& range) {
-            readBlock(buffer, range, RANGE_TO_EDGE_ID_DSET);
-        },
-        primaryRange,
-        min_gap_size,
-        max_aggregated_block_size);
+    auto secondaryRange = detail::readCanonicalSelection<std::array<uint64_t, 2>>(
+        indexGroup.getDataSet(RANGE_TO_EDGE_ID_DSET), primaryRange, RawIndex{{0, 2}});
 
     // Sort and eliminate empty ranges.
     secondaryRange = bulk_read::sortAndMerge(secondaryRange);

--- a/src/read_canonical_selection.hpp
+++ b/src/read_canonical_selection.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <vector>
-
 #include <highfive/H5File.hpp>
+
+#include "read_bulk.hpp"
 
 namespace bbp {
 namespace sonata {
 namespace detail {
-
 
 template <class Range>
 HighFive::HyperSlab make_hyperslab(const std::vector<Range>& ranges) {
@@ -28,6 +28,33 @@ std::vector<T> readCanonicalSelection(const HighFive::DataSet& dset, const Selec
     }
 
     return dset.select(make_hyperslab(selection.ranges())).template read<std::vector<T>>();
+}
+
+template <class T, class XRange, class YRange>
+std::vector<T> readCanonicalSelection(const HighFive::DataSet& dset,
+                                      const std::vector<XRange>& xranges,
+                                      const std::vector<YRange>& yranges) {
+    if (yranges.size() != 1) {
+        throw SonataError("Only yranges.size() == 1 has been implemented.");
+    }
+
+    size_t j_begin = std::get<0>(yranges[0]);
+    size_t j_end = std::get<1>(yranges[0]);
+
+    constexpr size_t min_gap_size = SONATA_PAGESIZE / (2 * sizeof(uint64_t));
+    constexpr size_t max_aggregated_block_size = 128 * min_gap_size;
+
+    auto readBlock = [&](auto& buffer, const auto& xrange) {
+        size_t i_begin = std::get<0>(xrange);
+        size_t i_end = std::get<1>(xrange);
+        dset.select({i_begin, j_begin}, {i_end - i_begin, j_end - j_begin}).read(buffer);
+    };
+
+    return bulk_read::bulkRead<T>([&readBlock](auto& buffer,
+                                               const auto& range) { readBlock(buffer, range); },
+                                  xranges,
+                                  min_gap_size,
+                                  max_aggregated_block_size);
 }
 
 }  // namespace detail


### PR DESCRIPTION
The point is to split reading of the dataset into a separate function, and then
make `resolve` safe for collective IO (assuming the newly introduced function
is).

The overload for reading a single `nodeID` is removed as it's unused now.