### PR TITLE
Use `using Range = std::array<Value, 2>`.

### DIFF
--- a/include/bbp/sonata/selection.h
+++ b/include/bbp/sonata/selection.h
@@ -14,7 +14,7 @@ class SONATA_API Selection
   public:
     using Value = uint64_t;
     using Values = std::vector<Value>;
-    using Range = std::pair<Value, Value>;
+    using Range = std::array<Value, 2>;
     using Ranges = std::vector<Range>;
 
     Selection(Ranges ranges);
@@ -57,19 +57,19 @@ Selection Selection::fromValues(Iterator first, Iterator last) {
     Selection::Range range{0, 0};
     while (first != last) {
         const auto v = *first;
-        if (v == range.second) {
-            ++range.second;
+        if (v == std::get<1>(range)) {
+            ++std::get<1>(range);
         } else {
-            if (range.first < range.second) {
+            if (std::get<0>(range) < std::get<1>(range)) {
                 ranges.push_back(range);
             }
-            range.first = v;
-            range.second = v + 1;
+            std::get<0>(range) = v;
+            std::get<1>(range) = v + 1;
         }
         ++first;
     }
 
-    if (range.first < range.second) {
+    if (std::get<0>(range) < std::get<1>(range)) {
         ranges.push_back(range);
     }
 

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -429,7 +429,7 @@ PYBIND11_MODULE(_libsonata, m) {
                          if (raw(i, 0) < 0 || raw(i, 1) < 0) {
                              throw SonataError("Negative value passed to Selection");
                          }
-                         ranges.emplace_back(raw(i, 0), raw(i, 1));
+                         ranges.push_back({uint64_t(raw(i, 0)), uint64_t(raw(i, 1))});
                      }
                      return Selection(ranges);
                  }

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -445,7 +445,19 @@ PYBIND11_MODULE(_libsonata, m) {
              }),
              "values"_a,
              "Selection from list of IDs: passing np.array with dtype np.uint64 is faster")
-        .def_property_readonly("ranges", &Selection::ranges, DOC_SEL(ranges))
+        .def_property_readonly(
+            "ranges",
+            [](const Selection& obj) {
+                const auto& ranges = obj.ranges();
+                auto list = py::list(ranges.size());
+                for (size_t i = 0; i < ranges.size(); ++i) {
+                    const auto& range = ranges[i];
+                    list[i] = py::make_tuple(std::get<0>(range), std::get<1>(range));
+                }
+
+                return list;
+            },
+            DOC_SEL(ranges))
         .def(
             "flatten", [](Selection& obj) { return asArray(obj.flatten()); }, DOC_SEL(flatten))
         .def_property_readonly("flat_size", &Selection::flatSize, DOC_SEL(flatSize))

--- a/python/tests/test_population.py
+++ b/python/tests/test_population.py
@@ -23,7 +23,7 @@ PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 
 class TestSelection(unittest.TestCase):
     def test_basic(self):
-        ranges = [(3, 5), (0, 3)]
+        ranges = [[3, 5], [0, 3]]
         selection = Selection(ranges)
         self.assertTrue(selection)
         self.assertEqual(selection.ranges, ranges)
@@ -53,7 +53,7 @@ class TestSelection(unittest.TestCase):
             [1, 3, 4, 1],
             [0, 0, 0, 0],
         ]
-        expected = [(1, 2), (3, 5), (1, 2)]
+        expected = [[1, 2], [3, 5], [1, 2]]
         self.assertEqual(Selection(values[0]).ranges, expected)
         self.assertEqual(Selection(np.array(values, dtype=np.uint64, order='C')[0]).ranges, expected)
         self.assertEqual(Selection(np.array(values, dtype=np.uint32, order='C')[0]).ranges, expected)
@@ -257,28 +257,29 @@ class TestEdgePopulation(unittest.TestCase):
         self.assertEqual(self.test_obj.target_nodes(Selection([])).tolist(), [])
 
     def test_afferent_edges(self):
-        self.assertEqual(self.test_obj.afferent_edges([1, 2]).ranges, [(0, 4), (5, 6)])
-        self.assertEqual(self.test_obj.afferent_edges(1).ranges, [(0, 1), (2, 4)])
+        self.assertEqual(self.test_obj.afferent_edges([1, 2]).ranges, [[0, 4], [5, 6]])
+        self.assertEqual(self.test_obj.afferent_edges(1).ranges, [[0, 1], [2, 4]])
 
     def test_efferent_edges(self):
-        self.assertEqual(self.test_obj.efferent_edges([1, 2]).ranges, [(0, 4)])
+        print(f"{type(self.test_obj.efferent_edges([1, 2]).ranges)=}", flush=True)
+        self.assertEqual(self.test_obj.efferent_edges([1, 2]).ranges, [[0, 4]])
         self.assertEqual(self.test_obj.efferent_edges(0).ranges, [])
 
     def test_connecting_edges(self):
-        self.assertEqual(self.test_obj.connecting_edges([1, 2], [1, 2]).ranges, [(0, 4)])
-        self.assertEqual(self.test_obj.connecting_edges(1, 1).ranges, [(0, 1)])
+        self.assertEqual(self.test_obj.connecting_edges([1, 2], [1, 2]).ranges, [[0, 4]])
+        self.assertEqual(self.test_obj.connecting_edges(1, 1).ranges, [[0, 1]])
 
     def test_select_all(self):
         self.assertEqual(self.test_obj.select_all().flat_size, 6)
 
     def test_library_enumeration(self):
         self.assertEqual(
-            self.test_obj.get_attribute("E-mapping-good", Selection([(0, 1), (2, 3)])).tolist(),
+            self.test_obj.get_attribute("E-mapping-good", Selection([[0, 1], [2, 3]])).tolist(),
             ["C", "C"]
         )
 
         self.assertEqual(
-            self.test_obj.get_enumeration( "E-mapping-good", Selection([(0, 1), (2, 3)])).tolist(),
+            self.test_obj.get_enumeration( "E-mapping-good", Selection([[0, 1], [2, 3]])).tolist(),
             [2, 2]
         )
 

--- a/python/tests/test_population.py
+++ b/python/tests/test_population.py
@@ -23,7 +23,7 @@ PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 
 class TestSelection(unittest.TestCase):
     def test_basic(self):
-        ranges = [[3, 5], [0, 3]]
+        ranges = [(3, 5), (0, 3)]
         selection = Selection(ranges)
         self.assertTrue(selection)
         self.assertEqual(selection.ranges, ranges)
@@ -53,7 +53,7 @@ class TestSelection(unittest.TestCase):
             [1, 3, 4, 1],
             [0, 0, 0, 0],
         ]
-        expected = [[1, 2], [3, 5], [1, 2]]
+        expected = [(1, 2), (3, 5), (1, 2)]
         self.assertEqual(Selection(values[0]).ranges, expected)
         self.assertEqual(Selection(np.array(values, dtype=np.uint64, order='C')[0]).ranges, expected)
         self.assertEqual(Selection(np.array(values, dtype=np.uint32, order='C')[0]).ranges, expected)
@@ -257,29 +257,28 @@ class TestEdgePopulation(unittest.TestCase):
         self.assertEqual(self.test_obj.target_nodes(Selection([])).tolist(), [])
 
     def test_afferent_edges(self):
-        self.assertEqual(self.test_obj.afferent_edges([1, 2]).ranges, [[0, 4], [5, 6]])
-        self.assertEqual(self.test_obj.afferent_edges(1).ranges, [[0, 1], [2, 4]])
+        self.assertEqual(self.test_obj.afferent_edges([1, 2]).ranges, [(0, 4), (5, 6)])
+        self.assertEqual(self.test_obj.afferent_edges(1).ranges, [(0, 1), (2, 4)])
 
     def test_efferent_edges(self):
-        print(f"{type(self.test_obj.efferent_edges([1, 2]).ranges)=}", flush=True)
-        self.assertEqual(self.test_obj.efferent_edges([1, 2]).ranges, [[0, 4]])
+        self.assertEqual(self.test_obj.efferent_edges([1, 2]).ranges, [(0, 4)])
         self.assertEqual(self.test_obj.efferent_edges(0).ranges, [])
 
     def test_connecting_edges(self):
-        self.assertEqual(self.test_obj.connecting_edges([1, 2], [1, 2]).ranges, [[0, 4]])
-        self.assertEqual(self.test_obj.connecting_edges(1, 1).ranges, [[0, 1]])
+        self.assertEqual(self.test_obj.connecting_edges([1, 2], [1, 2]).ranges, [(0, 4)])
+        self.assertEqual(self.test_obj.connecting_edges(1, 1).ranges, [(0, 1)])
 
     def test_select_all(self):
         self.assertEqual(self.test_obj.select_all().flat_size, 6)
 
     def test_library_enumeration(self):
         self.assertEqual(
-            self.test_obj.get_attribute("E-mapping-good", Selection([[0, 1], [2, 3]])).tolist(),
+            self.test_obj.get_attribute("E-mapping-good", Selection([(0, 1), (2, 3)])).tolist(),
             ["C", "C"]
         )
 
         self.assertEqual(
-            self.test_obj.get_enumeration( "E-mapping-good", Selection([[0, 1], [2, 3]])).tolist(),
+            self.test_obj.get_enumeration( "E-mapping-good", Selection([(0, 1), (2, 3)])).tolist(),
             [2, 2]
         )
 

--- a/src/edge_index.cpp
+++ b/src/edge_index.cpp
@@ -85,14 +85,7 @@ Selection resolve(const HighFive::Group& indexGroup, const std::vector<NodeID>& 
     // Sort and eliminate empty ranges.
     secondaryRange = bulk_read::sortAndMerge(secondaryRange);
 
-    // Copy `secondaryRange`, because the types don't match.
-    Selection::Ranges edgeIds;
-    edgeIds.reserve(secondaryRange.size());
-    for (const auto& range : secondaryRange) {
-        edgeIds.emplace_back(range[0], range[1]);
-    }
-
-    return Selection(std::move(edgeIds));
+    return Selection(std::move(secondaryRange));
 }
 
 

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -13,8 +13,9 @@ using Ranges = Selection::Ranges;
 
 void _checkRanges(const Ranges& ranges) {
     for (const auto& range : ranges) {
-        if (range.first >= range.second) {
-            throw SonataError(fmt::format("Invalid range: {}-{}", range.first, range.second));
+        if (std::get<0>(range) >= std::get<1>(range)) {
+            throw SonataError(
+                fmt::format("Invalid range: {}-{}", std::get<0>(range), std::get<1>(range)));
         }
     }
 }
@@ -35,13 +36,13 @@ Selection intersection_(const Ranges& lhs, const Ranges& rhs) {
 
     Ranges ret;
     while (it0 != r0.cend() && it1 != r1.cend()) {
-        auto start = std::max(it0->first, it1->first);
-        auto end = std::min(it0->second, it1->second);
+        auto start = std::max(std::get<0>(*it0), std::get<0>(*it1));
+        auto end = std::min(std::get<1>(*it0), std::get<1>(*it1));
         if (start < end) {
-            ret.emplace_back(start, end);
+            ret.push_back({start, end});
         }
 
-        if (it0->second < it1->second) {
+        if (std::get<1>(*it0) < std::get<1>(*it1)) {
             ++it0;
         } else {
             ++it1;
@@ -81,7 +82,7 @@ Selection::Values Selection::flatten() const {
     Selection::Values result;
     result.reserve(flatSize());
     for (const auto& range : ranges_) {
-        for (auto v = range.first; v < range.second; ++v) {
+        for (auto v = std::get<0>(range); v < std::get<1>(range); ++v) {
             result.emplace_back(v);
         }
     }

--- a/tests/test_edges.cpp
+++ b/tests/test_edges.cpp
@@ -17,7 +17,7 @@ namespace std {
 std::ostream& operator<<(std::ostream& oss, const Selection& selection) {
     oss << "{ ";
     for (const auto& range : selection.ranges()) {
-        oss << range.first << ":" << range.second << " ";
+        oss << std::get<0>(range) << ":" << std::get<1>(range) << " ";
     }
     oss << "}";
     return oss;

--- a/tests/test_report_reader.cpp
+++ b/tests/test_report_reader.cpp
@@ -48,9 +48,6 @@ TEST_CASE("SomaReportReader limits", "[base]") {
     // Inverted id
     REQUIRE_THROWS(pop.get(Selection({{2, 1}})));
 
-    // Negative ids
-    REQUIRE_THROWS(pop.get(Selection({{-1, 1}})));
-
     // Times out of range
     REQUIRE_THROWS(pop.get(Selection({{1, 2}}), 100., 101.));
 
@@ -119,9 +116,6 @@ TEST_CASE("ElementReportReader limits", "[base]") {
 
     // Inverted id
     REQUIRE_THROWS(pop.get(Selection({{2, 1}})));
-
-    // Negative ids
-    REQUIRE_THROWS(pop.get(Selection({{-1, 1}})));
 
     // Times out of range
     REQUIRE_THROWS(pop.get(Selection({{1, 2}}), 100., 101.));


### PR DESCRIPTION
By using an `std::array` we can removed the differences between `RawIndex` and `Selection::Ranges`. It also allows us to read `Selection::Ranges` from disk directly via the HighFive API.