### PR TITLE
Support collective reader.

### DIFF
--- a/python/libsonata/__init__.py
+++ b/python/libsonata/__init__.py
@@ -47,3 +47,22 @@ __all__ = [
     "version",
     "Hdf5Reader",
 ]
+
+def make_collective_reader(comm, collective_metadata, collective_transfer):
+    """Create an Hdf5Reader for collective I/O.
+
+    If MPI support is available via `libsonata_mpi`, then it will return
+    an Hdf5Reader for collective I/O on the given communicator.
+
+    This requires that the application uses libsonata in a collective way, e.g.
+    all ranks must read the same attributes in the same order.
+
+    If `libsonata_mpi` hasn't been installed, the function returns the default
+    Hdf5Reader.
+    """
+    try:
+        import libsonata_mpi
+        return libsonata_mpi.make_collective_reader(comm, collective_metadata, collective_transfer)
+
+    except ModuleNotFoundError:
+        return Hdf5Reader()


### PR DESCRIPTION
This allows:
```
from libsonata import make_collective_reader
```
Therefore any code that wants to use collective I/O can easily use the collective reader and it will automatically work even if their users can't/didn't install `libsonata_mpi`.

Unfortuntately, we can't mix `libsonata_mpi` and `libsonata` built from wheels, because the one needs pHDF5 and the other doesn't provide those. Hence, in the limited sites where collective IO is required, i.e. clusters with parallel filesystems, one needs to build both from source against the same version of HDF5.