### PR TITLE
Check more variants of CMake invocations.

### DIFF
--- a/ci/cpp_test.sh
+++ b/ci/cpp_test.sh
@@ -6,15 +6,17 @@
 set -euxo pipefail
 
 BUILD_DIR=build/build-cpp-test
-rm -rf "$BUILD_DIR"
-mkdir -p "$BUILD_DIR"
-cd "$BUILD_DIR"
 
 SONATA_VERSION=
 if ! git describe --tags > /dev/null 2>&1; then
     SONATA_VERSION='-DSONATA_VERSION=0.0.0'
     echo "Likely shallow git clone, faking SONATA_VERSION -> $SONATA_VERSION"
 fi
+
+# cmake && make
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+pushd "$BUILD_DIR"
 
 cmake $SONATA_VERSION                                                      \
     -DCMAKE_BUILD_TYPE=Release                                             \
@@ -23,3 +25,28 @@ cmake $SONATA_VERSION                                                      \
     ../..
 
 make -j all test
+popd
+
+# cmake --build && ctest
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+cmake $SONATA_VERSION                                                      \
+    -DCMAKE_BUILD_TYPE=Release                                             \
+    -DEXTLIB_FROM_SUBMODULES=ON                                            \
+    -DSONATA_CXX_WARNINGS=ON                                               \
+    -B "${BUILD_DIR}"
+
+cmake --build "${BUILD_DIR}" --parallel
+ctest --test-dir "${BUILD_DIR}"
+
+# cmake --build --target install && ctest
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+cmake $SONATA_VERSION                                                      \
+    -DCMAKE_BUILD_TYPE=Release                                             \
+    -DEXTLIB_FROM_SUBMODULES=ON                                            \
+    -DSONATA_CXX_WARNINGS=ON                                               \
+    -DCMAKE_INSTALL_PREFIX=install                                         \
+    -B "${BUILD_DIR}"
+
+cmake --build "${BUILD_DIR}" --parallel --target install


### PR DESCRIPTION
The failure of:
```
cmake --build build --target install
```
from a freshly configured `build` caused these additions.