### PR TITLE
Allow `sonata::sonata_{shared,static}`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,8 @@ foreach(TARGET sonata_shared sonata_static)
             PRIVATE gcov
         )
     endif()
+
+    add_library(sonata::${TARGET} ALIAS ${TARGET})
 endforeach(TARGET)
 
 set_target_properties(sonata_shared


### PR DESCRIPTION
When using libsonata as a submodule the targets were called `sonata_{shared,static}`. When using it via `find_package` they were called `sonata::sonata_{shared,static}`.

This commit introduces aliases for `sonata::sonata_{shared,static}`.