### PR TITLE
SimulationConfig: spike_threshold is float

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -265,7 +265,7 @@ class SONATA_API SimulationConfig
     struct Run {
         enum class IntegrationMethod { invalid = -1, euler, nicholson, nicholson_ion };
 
-        static constexpr int DEFAULT_spikeThreshold = -30;
+        static constexpr double DEFAULT_spikeThreshold = -30.0;
         static constexpr IntegrationMethod DEFAULT_IntegrationMethod = IntegrationMethod::euler;
         static constexpr int DEFAULT_stimulusSeed = 0;
         static constexpr int DEFAULT_ionchannelSeed = 0;
@@ -279,7 +279,7 @@ class SONATA_API SimulationConfig
         /// Random seed
         int randomSeed{};
         /// The spike detection threshold. Default is -30mV
-        int spikeThreshold = DEFAULT_spikeThreshold;
+        double spikeThreshold = DEFAULT_spikeThreshold;
         /// Selects the NEURON/CoreNEURON integration method. This parameter sets the NEURON
         /// global variable h.secondorder. Default 0 ('euler')
         IntegrationMethod integrationMethod = DEFAULT_IntegrationMethod;

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -410,7 +410,7 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.run.tstop, 1000)
         self.assertEqual(self.config.run.dt, 0.025)
         self.assertEqual(self.config.run.random_seed, 201506)
-        self.assertEqual(self.config.run.spike_threshold, -30)
+        self.assertEqual(self.config.run.spike_threshold, -35.5)
         self.assertEqual(self.config.run.integration_method, Run.IntegrationMethod.nicholson_ion)
         self.assertEqual(self.config.run.stimulus_seed, 111)
         self.assertEqual(self.config.run.ionchannel_seed, 222)
@@ -658,6 +658,7 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(conf.run.minis_seed, 0)
         self.assertEqual(conf.run.synapse_seed, 0)
         self.assertEqual(conf.run.electrodes_file, "")
+        self.assertEqual(conf.run.spike_threshold, -30.0)
 
     def test_simulation_config_failures(self):
         with self.assertRaises(SonataError) as e:

--- a/tests/data/config/simulation_config.json
+++ b/tests/data/config/simulation_config.json
@@ -27,7 +27,8 @@
          "synapse_seed": 444,
          "integration_method" : 2,
          "forward_skip": 500,
-         "electrodes_file": "$ELECTRODES_DIR/electrode_weights.h5"
+         "electrodes_file": "$ELECTRODES_DIR/electrode_weights.h5",
+         "spike_threshold": -35.5
     },
     "output": {
          "output_dir": "$OUTPUT_DIR/output",

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -309,7 +309,7 @@ TEST_CASE("SimulationConfig") {
         CHECK(config.getRun().tstop == 1000);
         CHECK(config.getRun().dt == 0.025);
         CHECK(config.getRun().randomSeed == 201506);
-        CHECK(config.getRun().spikeThreshold == -30);
+        CHECK(config.getRun().spikeThreshold == -35.5);
         CHECK(config.getRun().integrationMethod == SimulationConfig::Run::IntegrationMethod::nicholson_ion);
         CHECK(config.getRun().stimulusSeed == 111);
         CHECK(config.getRun().ionchannelSeed == 222);
@@ -638,6 +638,7 @@ TEST_CASE("SimulationConfig") {
         CHECK(config.getRun().minisSeed == 0);
         CHECK(config.getRun().synapseSeed == 0);
         CHECK(config.getRun().electrodesFile == "");
+        CHECK(config.getRun().spikeThreshold == -30.0);
     }
 
     SECTION("Exception") {


### PR DESCRIPTION
fixes https://github.com/BlueBrain/sonata-extension/issues/42