### PR TITLE
Simulation config: synapse_replay input files must be .h5

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -488,10 +488,8 @@ class SONATA_API SimulationConfig
     struct InputHyperpolarizing: public InputBase {};
 
     struct InputSynapseReplay: public InputBase {
-        /// The location of the file with the spike info for injection
+        /// The location of the file with the spike info for injection, file extension must be .h5
         std::string spikeFile;
-        /// The node set to replay spikes from
-        std::string source;
     };
 
     struct InputSeclamp: public InputBase {

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -861,10 +861,7 @@ PYBIND11_MODULE(_libsonata, m) {
                                                                                   "SynapseReplay")
         .def_readonly("spike_file",
                       &SimulationConfig::InputSynapseReplay::spikeFile,
-                      DOC_SIMULATIONCONFIG(InputSynapseReplay, spikeFile))
-        .def_readonly("source",
-                      &SimulationConfig::InputSynapseReplay::source,
-                      DOC_SIMULATIONCONFIG(InputSynapseReplay, source));
+                      DOC_SIMULATIONCONFIG(InputSynapseReplay, spikeFile));
 
     py::class_<SimulationConfig::InputSeclamp, SimulationConfig::InputBase>(simConf, "Seclamp")
         .def_readonly("voltage",

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -988,9 +988,9 @@ static const char *__doc_bbp_sonata_SimulationConfig_InputSubthreshold_percentLe
 
 static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay = R"doc()doc";
 
-static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_source = R"doc(The node set to replay spikes from)doc";
-
-static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_spikeFile = R"doc(The location of the file with the spike info for injection)doc";
+static const char *__doc_bbp_sonata_SimulationConfig_InputSynapseReplay_spikeFile =
+R"doc(The location of the file with the spike info for injection, file
+extension must be .h5)doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_ModificationBase = R"doc()doc";
 

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -556,8 +556,7 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.input('ex_replay').duration, 40000)
         self.assertEqual(self.config.input('ex_replay').node_set, "Column")
         self.assertEqual(self.config.input('ex_replay').spike_file,
-                         os.path.abspath(os.path.join(PATH, 'config/replay.dat')))
-        self.assertEqual(self.config.input('ex_replay').source, "ML_afferents")
+                         os.path.abspath(os.path.join(PATH, 'config/replay.h5')))
         self.assertEqual(self.config.input('ex_extracellular_stimulation').node_set, 'Column')
 
         self.assertEqual(self.config.input('ex_abs_shotnoise').input_type.name, "conductance")
@@ -675,3 +674,22 @@ class TestSimulationConfig(unittest.TestCase):
             """
             SimulationConfig(contents, "./")
         self.assertEqual(e.exception.args, ('`connection_overrides` must be an array', ))
+
+        with self.assertRaises(SonataError) as e:
+            contents = """
+            {
+              "run": { "random_seed": 12345, "dt": 0.05, "tstop": 1000 },
+              "inputs" : {
+                "ex_replay": {
+                    "input_type": "spikes",
+                    "module": "synapse_replay",
+                    "delay": 0.0,
+                    "duration": 40000.0,
+                    "spike_file": "replay.dat",
+                    "node_set": "Column"
+                }
+              }
+            }
+            """
+            SimulationConfig(contents, "./")
+        self.assertEqual(e.exception.args, ('Replay spike_file should be a SONATA h5 file', ))

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -507,8 +507,11 @@ SimulationConfig::Input parseInputModule(const nlohmann::json& valueIt,
         SimulationConfig::InputSynapseReplay ret;
         parseCommon(ret);
         parseMandatory(valueIt, "spike_file", debugStr, ret.spikeFile);
-        parseOptional(valueIt, "source", ret.source);
         ret.spikeFile = toAbsolute(basePath, ret.spikeFile);
+        const auto extension = fs::path(ret.spikeFile).extension().string();
+        if (extension != ".h5") {
+            throw SonataError("Replay spike_file should be a SONATA h5 file");
+        }
         return ret;
     }
     case Module::seclamp: {

--- a/tests/data/config/simulation_config.json
+++ b/tests/data/config/simulation_config.json
@@ -175,8 +175,7 @@
             "module": "synapse_replay",
             "delay": 0.0,
             "duration": 40000.0,
-            "spike_file": "replay.dat",
-            "source": "ML_afferents",
+            "spike_file": "replay.h5",
             "node_set": "Column"
         },
         "ex_extracellular_stimulation": {
@@ -184,7 +183,7 @@
             "module": "synapse_replay",
             "delay": 0.0,
             "duration": 40000.0,
-            "spike_file": "replay.dat",
+            "spike_file": "replay.h5",
             "node_set": "Column"
         },
         "ex_OU": {

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -506,8 +506,7 @@ TEST_CASE("SimulationConfig") {
             CHECK(input.delay == 0);
             CHECK(input.duration == 40000);
             CHECK(input.nodeSet == "Column");
-            CHECK(endswith(input.spikeFile, "replay.dat"));
-            CHECK(input.source == "ML_afferents");
+            CHECK(endswith(input.spikeFile, "replay.h5"));
         }
         {
             const auto input = nonstd::get<SimulationConfig::InputSeclamp>(config.getInput("ex_seclamp"));
@@ -1196,6 +1195,27 @@ TEST_CASE("SimulationConfig") {
                 "random_seed": 12345,
                 "dt": 0.05,
                 "tstop": 1000
+              }
+            })";
+            CHECK_THROWS_AS(SimulationConfig(contents, "./"), SonataError);
+        }
+        {
+            // Replay with a non-h5 file
+            auto contents = R"({
+              "run": {
+                "random_seed": 12345,
+                "dt": 0.05,
+                "tstop": 1000
+              },
+              "inputs" : {
+                "ex_replay": {
+                    "input_type": "spikes",
+                    "module": "synapse_replay",
+                    "delay": 0.0,
+                    "duration": 40000.0,
+                    "spike_file": "replay.dat",
+                    "node_set": "Column"
+                }
               }
             })";
             CHECK_THROWS_AS(SimulationConfig(contents, "./"), SonataError);


### PR DESCRIPTION
Following the change in https://github.com/BlueBrain/sonata-extension/pull/43
- Raise exception is "spike_file" for "spike_replay" input is not with `.h5` file extension
- Remove the "source" parameter