### PR TITLE
Bump fmt to 11.0.2 to be equivalent to nrn

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,11 @@ include extlib/CMakeLists.txt
 include extlib/nlohmann/json.hpp
 
 # fmt
-recursive-include extlib/fmt *
+recursive-include extlib/fmt/include *
+recursive-include extlib/fmt/src *
+recursive-include extlib/fmt/support/cmake *
+include extlib/fmt/CMakeLists.txt
+include extlib/fmt/*.rst
 
 # highfive
 recursive-include extlib/HighFive/include *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,10 +10,9 @@ include extlib/nlohmann/json.hpp
 # fmt
 recursive-include extlib/fmt/include *
 recursive-include extlib/fmt/src *
-recursive-include extlib/fmt/support/cmake *.cmake
+recursive-include extlib/fmt/support/cmake *
 include extlib/fmt/CMakeLists.txt
 include extlib/fmt/*.rst
-include extlib/fmt/support/cmake/fmt.pc.in
 
 # highfive
 recursive-include extlib/HighFive/include *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,7 @@ recursive-include extlib/fmt/src *
 recursive-include extlib/fmt/support/cmake *
 include extlib/fmt/CMakeLists.txt
 include extlib/fmt/*.rst
+include extlib/fmt/README.md
 
 # highfive
 recursive-include extlib/HighFive/include *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ recursive-include extlib/fmt/support/cmake *
 include extlib/fmt/CMakeLists.txt
 include extlib/fmt/*.rst
 include extlib/fmt/README.md
+include extlib/fmt/ChangeLog.md
 
 # highfive
 recursive-include extlib/HighFive/include *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,11 +8,7 @@ include extlib/CMakeLists.txt
 include extlib/nlohmann/json.hpp
 
 # fmt
-recursive-include extlib/fmt/include *
-recursive-include extlib/fmt/src *
-recursive-include extlib/fmt/support/cmake *
-include extlib/fmt/CMakeLists.txt
-include extlib/fmt/*.rst
+recursive-include extlib/fmt *
 
 # highfive
 recursive-include extlib/HighFive/include *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,7 @@ recursive-include extlib/fmt/src *
 recursive-include extlib/fmt/support/cmake *.cmake
 include extlib/fmt/CMakeLists.txt
 include extlib/fmt/*.rst
+include extlib/fmt/support/cmake/fmt.pc.in
 
 # highfive
 recursive-include extlib/HighFive/include *


### PR DESCRIPTION
I blindly try to fix https://bbpgitlab.epfl.ch/hpc/cellular/nrn/-/jobs/1431896
I cannot compile libsonata locally btw