### PR TITLE
Use aggregated reading for 1D selections.

### DIFF
--- a/src/hdf5_reader.hpp
+++ b/src/hdf5_reader.hpp
@@ -28,12 +28,7 @@ class Hdf5PluginRead1DDefault: virtual public Hdf5PluginRead1DInterface<T>
   public:
     std::vector<T> readSelection(const HighFive::DataSet& dset,
                                  const Selection& selection) const override {
-        if (selection.ranges().empty()) {
-            return {};
-        }
-
-        return dset.select(detail::_makeHyperslab(selection.ranges()))
-            .template read<std::vector<T>>();
+        return detail::readCanonicalSelection<T>(dset, selection);
     }
 };
 

--- a/src/read_canonical_selection.hpp
+++ b/src/read_canonical_selection.hpp
@@ -16,7 +16,7 @@ std::vector<T> readCanonicalSelection(const HighFive::DataSet& dset, const Selec
     }
 
     constexpr size_t min_gap_size = SONATA_PAGESIZE / sizeof(T);
-    constexpr size_t max_aggregated_block_size = 16 * min_gap_size;
+    constexpr size_t max_aggregated_block_size = 1 * min_gap_size;
 
     auto readBlock = [&](auto& buffer, const auto& range) {
         size_t i_begin = std::get<0>(range);


### PR DESCRIPTION
Aggregating scattered reads was implemented in

  * 836646574302c2438a8455595d996c5be52a84a8 adds bulkRead,
  * a7d1453fadce88201d009ea3c843f562491238bf for 2D selections.

However, it was only used for edge indexes. We measured the performance on an HDD and SSD for random access patterns with different streak lengths. We found that for all cases, including streak length of 1, using bulkRead was preferrable over both `0.1.24` (using `HighFive::ElementSet`) and `0.1.29` (using `HighFive::HyperSlab`).

We investigated if aggregating multiple pages was beneficial and found that it was not.